### PR TITLE
Cale sex tweaks

### DIFF
--- a/js/event/nomads/cale-sex.js
+++ b/js/event/nomads/cale-sex.js
@@ -17,7 +17,7 @@ Scenes.Cale.TentSex = function() {
 		playername : player.name
 	};
 	
-	Text.Add("The two of you duck inside the small cloth-enclosure, even smaller than your own tent among the nomads. It still holds enough space to house a set of warm bedrolls, which is all you are interested in either way.", parse);
+	Text.Add("The two of you duck inside the small cloth enclosure, even smaller than your own tent among the nomads. It still holds enough space to house a set of warm bedrolls, which is all you are interested in either way.", parse);
 	Text.NL();
 	Text.Add("Cale shrugs out of his clothes, pulling you into a close embrace, his fur tickling you. <i>“Why don’t we get started, [playername]?”</i> he murmurs, nipping your neck playfully.", parse);
 	Text.Flush();
@@ -122,15 +122,16 @@ Scenes.Cale.OutsideSex = function() {
 	var parse = {
 		playername : player.name,
 		HeShe : rosalin.HeShe(),
-		heshe : rosalin.heshe()
+		heshe : rosalin.heshe(),
+		himher : rosalin.himher()
 	};
 	
 	if(cale.Slut() < 60) {
-		Text.Add("<i>“I’m front of everyone?”</i> he asks a bit nervously.", parse);
+		Text.Add("<i>“In front of everyone?”</i> he asks a bit nervously.", parse);
 		Text.NL();
 		Text.Add("Why not? He doesn’t seem to mind the audience when it’s him and Rosalin making the beast with two backs.", parse);
 		Text.NL();
-		Text.Add("<i>“Well, Rosie is a bit different. I’m sure you noticed. [HeShe] does whatever [heshe] wants, whenever and wherever [heshe] wants. It’s not a good idea to say no to her, so I don’t really have an option. I just accept it. But you though… wouldn’t it be more comfortable to go back to my tent?”</i>  he offers tentatively.", parse);
+		Text.Add("<i>“Well, Rosie is a bit different. I’m sure you noticed. [HeShe] does whatever [heshe] wants, whenever and wherever [heshe] wants. It’s not a good idea to say no to [himher], so I don’t really have an option. I just accept it. But you though… wouldn’t it be more comfortable to go back to my tent?”</i> he offers tentatively.", parse);
 		Text.NL();
 		Text.Add("You shake your head; no, you want to do it here and now.", parse);
 		Text.NL();
@@ -263,7 +264,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 	Text.NL();
 	Text.Add("Settling down on the [log], Cale leans back, grunting as you coax him to full hardness with your fingers and a few quick licks of your tongue. At this range, his nine inch cock is very impressive - thick and veiny, with the massive knot lurking at its base. A drop of pre is forming on his tip, leaking out of his cumslit down his tapered glans.", parse);
 	Text.NL();
-	Text.Add("With his musky taste still lingering on your tongue, you are eager to dig in, to wrap your lips around his meaty wolf-hood. Starting low, you slowly lick your way up his shaft, lathering him from root to tip in your saliva.", parse);
+	Text.Add("With his musky taste still lingering on your tongue, you are eager to dig in - and do so by wrapping your lips around his meaty wolf-hood. Starting low, you slowly lick your way up his shaft, lathering him from root to tip in your saliva.", parse);
 	Text.NL();
 	Text.Add("<i>“Come on, stop teasing,”</i> Cale pants, shifting his hips slightly, rubbing his cock against your upturned face. He gently caresses your [hairDesc], not so gently urging you to get to sucking. Grasping him just above the knot, you give him a few more licks before rising to the level of his head. Your puckered lips hover a fraction of an inch from his trembling glans.", parse);
 	Text.Flush();
@@ -288,7 +289,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 			Text.NL();
 			Text.Add("You still have a ways to go before you are deepthroating all of his impressive cock, but you let your hands busy themselves with the parts of him that are still in the open. You swap between stroking the lower end of his shaft - taking particular note of his sensitive knot - and fondling his sack, imagining yourself hearing the seed sloshing within.", parse);
 			Text.NL();
-			Text.Add("As if reading your mind, the wolf groans appreciatively. <i>“Got a very special gift building up for you, my dear,”</i> he whispers, breathing heavily. <i>“A big fat lupine load, meant to knock some lucky girl up with my pups. Instead, I’m gonna pour it down your throat, ain’t I nice?”</i>", parse);
+			Text.Add("As if reading your mind, the wolf groans appreciatively. <i>“Got a very special gift building up for you, my dear,”</i> he whispers, breathing heavily. <i>“A big, fat lupine load meant to knock some lucky girl up with my pups. Instead, I’m gonna pour it down your throat, ain’t I nice?”</i>", parse);
 			Text.NL();
 			if(cale.Slut() >= 60) {
 				Text.Add("<i>“Not promising it’ll be as big as when I’ve got a cock stuck up my butt, but I promise to do my best,”</i> he adds, grinning.", parse);
@@ -316,11 +317,11 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 			Text.NL();
 			Text.Add("<i>“How about that blowjob, [playername]?”</i> he asks uncertainly, wincing as you tighten your grip slightly. Instead of responding, you jerk him more strongly, trying to push a reaction from him. The lips he so desire hovers a fraction of an inch from the tip of his cock, but never touching it. Your smile widens as the wolf whimpers, his dick throbbing in your hand.", parse);
 			Text.NL();
-			Text.Add("Several times you make as if to wrap your lips around his girth, even going as far as opening your mouth, your tongue almost touching his head. Try as he might, Cale has no choice but to take things at your pace, as you tighten your grip around his sensitive scrotum each time he tries to urge you on by rocking his hips, or to guide your head with his hand.", parse);
+			Text.Add("Several times you make as if to wrap your lips around his girth, even going as far as opening your mouth, your tongue almost touching his head. Try as he might, Cale has no choice but to take things at your pace as you tighten your grip around his sensitive scrotum each time he tries to urge you on by rocking his hips, or to guide your head with his hand.", parse);
 			Text.NL();
-			Text.Add("<i>“Aah… j-just suck it! S-stop teasing me!”</i> the wolf moans pitifully. Ignoring him, you move your [hand]s higher; one encircling his knot as well as you are able, the other thumbing at his tapered tip. Cale gives another shudder at your rougher teasing, a bead of precum forming on the tip of his cock.", parse);
+			Text.Add("<i>“Aah… j-just suck it! S-stop teasing me!”</i> the wolf moans pitifully. Ignoring him, you move your [hand]s higher - one encircling his knot as well as you are able, the other thumbing at his tapered tip. Cale gives another shudder at your rougher teasing, a bead of pre-cum forming on the head of his cock.", parse);
 			Text.NL();
-			Text.Add("<i>“Please?”</i> he huffs, panting as you blow on his sensitive glans, your open mouth hovering just above his dick. Your diligent jerking seems to be paying off, as Cale’s throbbing intensifies. <i>“Ah, that feels good~”</i> he groans, closing his eyes in pleasure. They shoot right back open again when you finally decide to make your move.", parse);
+			Text.Add("<i>“Please?”</i> he huffs, panting as you blow on his sensitive glans, your open mouth hovering just above his dick. Your diligent jerking seems to be paying off as Cale’s throbbing intensifies. <i>“Ah, that feels good~”</i> he groans, closing his eyes in pleasure. They shoot right back open again when you finally decide to make your move.", parse);
 			Text.NL();
 			Text.Add("In one fell swoop, you dive down on his cock, almost swallowing it whole. The wolf gasps as he is pushed to the edge, shooting a small wad of pre deep down your throat. You bob your head up until only his tip remains in your mouth, only to push down all the way, taking him knot and all.", parse);
 			Text.NL();
@@ -356,9 +357,9 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 				Text.Add("<i>“Mm, that feels nice...”</i> he moans, shifting slightly.", parse);
 			else
 				Text.Add("<i>“H-hey!”</i> Quizzically, you ask him if he wants you to stop - the unspoken implication being that he won’t be getting that blowjob either. <i>“I- uh, I guess it’s fine,”</i> he replies, looking a bit uncomfortable.", parse);
-			Text.Add(" The wolf’s [tight] rosebud opens up to your probing finger, offering little resistance to the invading object. Whether due to willingness or to your simultaneous blowjob, neither does Cale. Further emboldened, you add a second digit to your anal teasing, searching for and quickly finding his sensitive prostate.", parse);
+			Text.Add(" The wolf’s [tight] rosebud opens up to your probing finger, offering little resistance to the invading object. Whether it is due to willingness or to your simultaneous blowjob, neither does Cale. Further emboldened, you add a second digit to your anal teasing, searching for and quickly finding his sensitive prostate.", parse);
 			Text.NL();
-			Text.Add("You start to enthusiastically blow the wolf, going deeper and deeper on his cock; all the while keeping up your fingering of his butt. Before long, you plant a kiss on his furred sheath, his nine inch erection halfway down your throat and his thick knot resting on your [tongueDesc].", parse);
+			Text.Add("You start to enthusiastically blow the wolf, going deeper and deeper on his cock; all the while, you keep up your fingering of his butt. Before long, you plant a kiss on his furred sheath, his nine inch erection halfway down your throat and his thick knot resting on your [tongueDesc].", parse);
 			Text.NL();
 			
 			var max = virgin ? 25 : 40;
@@ -373,19 +374,19 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 	Gui.SetButtonsFromList(options, false, null);
 	
 	Gui.Callstack.push(function() {
-		Text.Add("You suppress your gag reflex at the long lupine dick thrusting down your throat, its conical tip helping Cale to plunge deeper inside of you. Lapping at his knot with your [tongueDesc], you moan softly, sending delightful vibrations along his member as you coax him slowly and steadily deeper. You worm your tongue inside his sheath as far as you can, further teasing him as it slides against the sensitive flesh.", parse);
+		Text.Add("You suppress your gag reflex at the long lupine dick thrusting down your throat, its conical tip helping Cale to plunge farther inside of you. Lapping at his knot with your [tongueDesc], you moan softly, sending delightful vibrations along his member as you coax him slowly and steadily deeper. You worm your tongue inside his sheath as far as you can, further teasing him as it slides against the sensitive flesh.", parse);
 		Text.NL();
-		Text.Add("<i>“Damn, [playername]. If you keep this up I’m gonna blow!”</i>", parse);
+		Text.Add("<i>“Damn, [playername]. If you keep this up, I’m gonna blow!”</i>", parse);
 		Text.NL();
-		Text.Add("Well, that just won’t do, now will it? You draw your tongue from his sheath and slowly pull your head back, letting his member glide out between your lips until it is bobbing wetly in the air before you. You kiss him gently on the very tip of his glans, stealing a quick lick at his urethra, and then move your mouth down to his knot. Slowly and luxuriantly, you stroke the very tip of your [tongueDesc] over his knot, then lick him again just above it. In a series of smooth, gliding motions, you gently lick your way back up to his tip, then open your mouth and envelop him once more. You suckle his length with smooth, soft gulping motions, making Cale moan and buck against you.", parse);
+		Text.Add("Well, that just won’t do, now will it? You draw your tongue from his sheath and slowly pull your head back, letting his member glide out between your lips until it is bobbing wetly in the air before you. You kiss him gently on the very tip of his glans, stealing a quick lick at his urethra, and then move your mouth down to his knot. Slowly and luxuriantly, you stroke the very tip of your [tongueDesc] over his knot, then lick him again just above it. In a series of smooth, gliding motions, you gently lap your way back up to his cockhead, then open your maw and envelop him once more. You suckle his length with smooth, soft gulping motions, making Cale moan and buck against you.", parse);
 		Text.NL();
 		if(finger) {
-			Text.Add("You slowly withdraw your finger from Cale’s used tailhole, easing up on the pressure you’re exerting. With teasing strokes, you trace circles around his flexing ring, even making the occasional tantalising thrust inside, but your motions are always light, and you avoid going so deep as to stroke his prostate. He won’t get off that easily...", parse);
+			Text.Add("You slowly withdraw your finger from Cale’s used tailhole, easing up on the pressure you’re exerting. With teasing strokes, you trace circles around his flexing ring, even making the occasional tantalizing thrust inside, but your motions are always light, and you avoid going so deep as to stroke his prostate. He won’t get off that easily...", parse);
 			Text.NL();
 		}
 		Text.Add("Unhappy with his moving around, you gently but firmly take hold of his swollen balls, rolling the fur-covered orbs around with your fingers, kneading the sensitive flesh even as you continue to almost lazily suck his cock.", parse);
 		Text.NL();
-		Text.Add("Up above Cale is completely helpless to your ministrations, panting and drooling like a dog. His knees are shaking and you can hear the thumping of his tail as it wags erratically about. At this point you’re totally in control, and you have a feeling that submitting him to any more attention would surely make him empty his balls. Now… how to end this...", parse);
+		Text.Add("Up above, Cale is completely helpless to your ministrations, panting and drooling like a dog. His knees are shaking and you can hear the thumping of his tail as it wags erratically about. At this point, you’re totally in control, and you have a feeling that submitting him to any more attention would surely make him empty his balls. Now… how to end this...", parse);
 		Text.Flush();
 		
 		var mess = false;
@@ -396,15 +397,15 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 			func : function() {
 				Text.Clear();
 				if(finger) {
-					Text.Add("You line your finger up and, in a single smooth motion, you push it inside of Cale’s used tailhole to the knuckle, twisting as you do so in order to better grind against his prostate.", parse);
+					Text.Add("You line your finger up and - in a single, smooth motion - you push it inside of Cale’s used tailhole to the knuckle, twisting as you do so in order to better grind against his prostate.", parse);
 					Text.NL();
 				}
-				Text.Add("Your hand leaves the wolf’s balls alone, fingers curling into a ring behind his knot, so tight you’re practically pinching him, sealing his cumvein closed good and tight. You open your mouth and gulp down his cock, letting it slide down your throat until you can kiss the bulging mass of his knot, which you do, wetly slurping it with your lips. You can feel it practically explode, a strangled, gasping moan erupting from Cale’s lips as he goes slack; only your squeezing fingers around his dick keep him from falling over.", parse);
+				Text.Add("Your hand leaves the wolf’s balls alone, fingers curling into a ring behind his knot so strong that you’re practically pinching him, sealing his cumvein closed good and tight. You open your mouth and gulp down his cock, letting it slide down your throat until you can kiss the bulging mass of his bulb, which you do, wetly slurping it with your lips. You can feel it virtually explode, a strangled, gasping moan erupting from Cale’s lips as he goes slack; only your squeezing digits around his dick keep him from falling over.", parse);
 				Text.NL();
 				parse["finger"] = finger ? ", now removed from his ass" : "";
 				Text.Add("Once he’s managed to get a more stable stance, you start to glide your head back until only his glans remains sealed between your lips. With your other hand[finger], you curl your fingers into a firm ring around his dick and begin sliding it up and down his length. As your hand moves toward you, you squeeze down; as it slides back, you release, almost as if you were milking him.", parse);
 				Text.NL();
-				Text.Add("Cale wriggles and whimpers, soft barks of pleasure escaping his lips and he thrashes around. Eventually, the pressure building behind his knot is so great you doubt you can hold him back any longer, and you release him, holding on with both hands to keep his dick from escaping your mouth. Thick strands of hot, salty wolf-spunk gush into your mouth, gurgling down into your belly as you gulp with all your might, audibly slurping and sucking until you have swallowed every last drop the now-spent wolf has to give you.", parse);
+				Text.Add("Cale wriggles and whimpers, soft barks of pleasure escaping his lips as he thrashes around. Eventually, the pressure building behind his knot is so great that you doubt you can hold him back any longer - and you release him, holding on with both hands to keep his dick from escaping your mouth. Thick strands of hot, salty wolf-spunk gush into your maw, gurgling down into your belly as you gulp with all your might, audibly slurping and sucking until you have swallowed every last drop the now-spent wolf has to give you.", parse);
 				Text.NL();
 				
 				var scenes = new EncounterTable();
@@ -423,7 +424,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 				
 				scenes.Get();
 				
-				Text.Add("<i>“Ugh. I-I think I need to rest a bit.”</i> Cale slides down the log, sitting on the floor, completely drained. <i>“Damn, [playername]. My balls hurt!,”</i> he growls, gently fondling his abused orbs. <i>“I don’t think I’ve ever been dry before today. How do you even do that?”</i>", parse);
+				Text.Add("<i>“Ugh. I-I think I need to rest a bit.”</i> Cale slides down the log, sitting on the ground, completely drained. <i>“Damn, [playername]. My balls hurt!,”</i> he growls, gently fondling his abused orbs. <i>“I don’t think I’ve ever been dry before today. How do you even do that?”</i>", parse);
 				Text.NL();
 				if(player.sexlevel <= 2)
 					Text.Add("You simply shrug, explaining you merely did what came to you naturally.", parse);
@@ -432,7 +433,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 				else
 					Text.Add("A smug smirk adorns your features as you boast that with your level of expertise in the carnal arts, you could probably torture someone with pure ecstasy... wouldn’t he agree, hmm?", parse);
 				Text.NL();
-				Text.Add("<i>“I think I’m going to stick here for a while… yeah… maybe take a nap.”</i> He opens his maw wide for a drawn out yawn. <i>“Scuse me, [playername].”</i>", parse);
+				Text.Add("<i>“I think I’m going to stick here for a while… yeah… maybe take a nap.”</i> He opens his maw wide for a drawn-out yawn. <i>“'Scuse me, [playername].”</i>", parse);
 				Text.NL();
 				Text.Add("That’s Cale alright; he really needs to work on his stamina. Seeing no reason to disrupt him from his nap, you get up and start to gather your things, slipping back into your [armorDesc]. By the time you’re finished dressing up again, the wolf-morph is out like a snuffed candle. You can’t resist a grin and gently petting him between the ears before you wander off, leaving him to his sleep.", parse);
 				Text.NL();
@@ -446,10 +447,10 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 				Text.Clear();
 				Text.Add("You give the wolf’s shaft a final round of polishing before releasing it from your hungry lips, grasping it in both hands. Pointing his cumslit right at your open mouth, you enthusiastically jerk him off, looking up into his eyes.", parse);
 				Text.NL();
-				Text.Add("<i>“Mmm, keep going, just like that,”</i> Cale pants, his cock twitching erratically in your hands. <i>“It’s gonna be a big one, don’t say I didn’t warn you!”</i> Grinning, you tell him that you expect no less from a big bad wolf like him. You can hardly wait to taste his fertile seed, to have him splash it all over your body and cover you in his jizz.", parse);
+				Text.Add("<i>“Mmm, keep going... just like that,”</i> Cale pants, his cock twitching erratically in your hands. <i>“It’s gonna be a big one - don’t say I didn’t warn you!”</i> Grinning, you tell him that you expect no less from a big, bad wolf like him. You can hardly wait to taste his fertile seed, to have him splash it all over your body and cover you in his jizz.", parse);
 				Text.NL();
 				parse["breast"] = player.FirstBreastRow().Size() > 3 ? Text.Parse(", between your [breastDesc]", parse) : "";
-				Text.Add("Egged on by your sultry, encouraging whispers, it’s not long before the wolf lets out a howl, his pent-up reserve of semen rushing from his sloshing balls and through his swelling knot. The first volley hits you squarely on your [tongueDesc]; a thick serving of wolf-spunk for your starving taste buds. The following shots stray to your [faceDesc], your [hairDesc] and down your front[breast].", parse);
+				Text.Add("Egged on by your sultry, encouraging whispers, it’s not long before the wolf lets out a howl, his pent-up reserve of semen rushing from his sloshing balls and through his swelling knot. The first volley hits you squarely on your [tongueDesc], a thick serving of wolf-spunk for your starving taste buds. The following shots stray to your [faceDesc], your [hairDesc] and down your front[breast].", parse);
 				Text.NL();
 				Text.Add("Hobbling slightly, the wolf-morph leans down and scratch you behind your [earDesc], commending you for a job well done. <i>“Damn, you look a right mess now, [playername],”</i> Cale grins at you. <i>“How do you like the new coat of paint I gave you? You look just <b>lovely</b> in white.”</i>", parse);
 				Text.NL();
@@ -464,7 +465,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 			options.push({ nameStr : "Reverse",
 				func : function() {
 					Text.Clear();
-					Text.Add("With drops of his pre still lingering on your [tongueDesc], you pull off his cock, rising in one smooth motion to give the wolf a big fat kiss. He sputters, losing his balance in a vain effort to get away from you, which makes pushing him on his back all the more easy. A sharp shove and the confused Cale is prone, ass propped up in the air by the [log]. He gasps as you shove your fingers back into his [cAnusDesc], spreading him wide.", parse);
+					Text.Add("With drops of his pre still lingering on your [tongueDesc], you pull off his cock, rising in one smooth motion to give the wolf a big, fat kiss. He sputters, losing his balance in a vain effort to get away from you, which makes pushing him on his back all the more easy. A sharp shove and the confused Cale is prone, ass propped up in the air by the [log]. He gasps as you shove your fingers back into his [cAnusDesc], spreading him wide.", parse);
 					Text.NL();
 					if(virgin)
 						Text.Add("<i>“N-no,”</i> he pants, deep down realizing what you are building up toward. Regardless, he makes no move to stop you, too caught up with pleasure to offer more than a token resistance.", parse);
@@ -473,12 +474,12 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 					else
 						Text.Add("<i>“Ngh… caught me by surprise there!”</i> he pants, shuddering as you simultaneously jerk him off and finger him.", parse);
 					Text.NL();
-					Text.Add("Pushing your fingers into the knuckle and twisting, it’s an easy feat to find the wolf’s sensitive prostate, and you set to rubbing against it insistently. Cale squirms and moans, his cock throbbing erratically. Smirking, you ease up on your handjob, giving his knot a squeeze before grabbing his member right below the tip, aiming it straight at his face. You are going to get him off with only his ass.", parse);
+					Text.Add("Pushing your fingers up to the knuckle and twisting, it’s an easy feat to find the wolf’s sensitive prostate, and you set to rubbing against it insistently. Cale squirms and moans, his cock throbbing erratically. Smirking, you ease up on your handjob, giving his knot a squeeze before grabbing his member right below the tip, aiming it straight at his face. You are going to get him off with only his ass.", parse);
 					Text.NL();
 					parse["fingering"] = cale.Slut() >= 60 ? "fisting" : "fingering";
 					Text.Add("The wolf’s expression is a delightful mixture of shame and lust. He just whimpers: <i>“P-please,”</i> but the exact meaning of his words is lost in the heat of the moment. Not that you are about to stop at this point. Funneling all your effort into [fingering] Cale, you go to town on his ass.", parse);
 					Text.NL();
-					Text.Add("<i>“Fuuuck!”</i> he groans as you mash his prostate, trying your best to milk him for cum. Trying and succeeding, as the wolf explodes in an impressive cascade of thick seed, spraying in almost opaque white strands across his body. Your aim is true, and the brunt of Cale’s load hits him right in the face, splattering all over his tongue and hair. Finally, his climax abates, and he goes limp in your hands, his swollen knot twitching uselessly. Grinning, you pull your fingers out of his butt, asking if he liked it.", parse);
+					Text.Add("<i>“Fuuuck!”</i> he groans as you mash his prostate, trying your best to milk him for cum. Trying and succeeding, the wolf explodes in an impressive cascade of thick seed, spraying in almost opaque white strands across his body. Your aim is true, and the brunt of Cale’s load hits him right in the face, splattering all over his tongue and hair. Finally, his climax abates, and he goes limp in your hands, his swollen knot twitching uselessly. Grinning, you pull your fingers out of his butt, asking if he liked it.", parse);
 					Text.NL();
 					if(cale.Slut() < 30)
 						Text.Add("The wolf is too spent to do anything but whimper, drained of all energy. You take that as a yes.", parse);
@@ -505,7 +506,7 @@ Scenes.Cale.SexSuckHimEntryPoint = function(outside) {
 			if(outside)
 				Text.Add("Cale stretches a bit before returning to his seat on the log, thanking you for helping him relieve some tension.", parse);
 			else
-				Text.Add("Before you leave the tent, you cuddle a bit with the big fluffy wolf.", parse);
+				Text.Add("Before you leave the tent, you cuddle a bit with the big, fluffy wolf.", parse);
 			Text.Flush();
 			
 			cale.relation.IncreaseStat(100, 2);
@@ -592,7 +593,7 @@ Scenes.Cale.SexGetBJ = function(outside) {
 			Gui.SetButtonsFromList(options, false, null);
 		}
 		else {
-			Text.Add("<i>“No offense, but this wolf doesn’t swing that way, ya know?”</i> Cale waves off your suggestive remark. <i>“Now if <b>you</b> want to suck <b>my</b> cock, that’d be a different story.”</i> The cock-sure wolf grins, winking at you.", parse);
+			Text.Add("<i>“No offense, but this wolf doesn’t swing that way, ya know?”</i> Cale waves off your suggestive remark. <i>“Now if <b>you</b> want to suck <b>my</b> cock, that’d be a different story.”</i> The cocksure wolf grins, winking at you.", parse);
 			Text.Flush();
 			
 			Scenes.Cale.Prompt();
@@ -643,14 +644,14 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 	
 	var sneakyFirst = (cale.flags["trickBJ"] == 0);
 	
-	Text.Add("<i>“Now, lets get started on you, shall we?”</i> Quickly shrugging out of your [lowerArmorDesc], you pull out your [multiCockDesc]. ", parse);
+	Text.Add("<i>“Now, let's get started on you, shall we?”</i> Quickly shrugging out of your [lowerArmorDesc], you pull out your [multiCockDesc]. ", parse);
 	
 	if(sneaky) {
 		cale.flags["trickBJ"]++;
 		
-		parse["legs"] = player.LowerBodyType() != LowerBodyType.Single ? ", spreading your legs" : "";
+		parse["legs"] = player.LowerBodyType() != LowerBodyType.Single ? ", spreading your legs," : "";
 		parse["balls"] = player.HasBalls() ? Text.Parse(" and [ballsDesc]", parse) : "";
-		Text.Add("Cale gulps at the sight of your slick shaft[s], but is still enticed with the promise of your pussy. Feeling that he needs some encouragement, you lie down[legs] and shifting your cock[s][balls] aside, revealing your [vagDesc].", parse);
+		Text.Add("Cale gulps at the sight of your slick shaft[s], but is still enticed with the promise of your pussy. Feeling that he needs some encouragement, you lie down[legs] and shift your cock[s][balls] aside to reveal your [vagDesc].", parse);
 		Text.NL();
 		Text.Add("Taking your invitation, the wolf greedily digs into your folds, lapping at your labia with his long, flexible tongue. You sigh in pleasure, leaning back. ", parse);
 		if(player.HasBalls())
@@ -665,11 +666,11 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 		
 		Text.Add("As you lean back even further, you are going to need both arms to prop yourself up. Stretching languidly, you put your weight on your elbows, smiling faintly when you see the wolf wince as your [multiCockDesc] flops onto his face. You let him keep up his lapping for a while, chuckling internally as he unsuccessfully tries to ignore your erection[s] rubbing his forehead.", parse);
 		Text.NL();
-		Text.Add("<i>“How about we change positions?”</i> Cale suggests, surfacing for air. The wolf tries to avoid looking directly at your stiff member[s] - a feat that is hard to pull off, as [itThey] [isAre] hovering a mere inch from his face. You nod, appearing to humor him. You instruct the soon-to-be-cocksucker to roll over on his back, and shuffle around so your bared crotch is hovering over his face. Cale seems happy, as he doesn’t have to worry about your [multiCockDesc] from this angle. How naive.", parse);
+		Text.Add("<i>“How about we change positions?”</i> Cale suggests, surfacing for air. The wolf tries to avoid looking directly at your stiff member[s] - a feat that is hard to pull off as [itThey] [isAre] hovering a mere inch from his face. You nod, appearing to humor him. You instruct the soon-to-be-cocksucker to roll over on his back, and shuffle around so your bared crotch is hovering over his face. Cale seems happy as he doesn’t have to worry about your [multiCockDesc] from this angle. How naive.", parse);
 		Text.NL();
 		Text.Add("Taking the initiative, you sink down on the wolf’s raised snout, letting his long tongue drill into your cooch. He’s doing a very good job of it - almost making you lose your flow - but your [multiCockDesc] is quick to remind you of your plan. You let him settle into it, luring him in with a false sense of security - not that you don’t enjoy yourself - before setting your plan into motion.", parse);
 		Text.NL();
-		Text.Add("Moaning encouragingly, you start grinding your [hipsDesc] erratically, rubbing your cunt on the canine’s face. Spurred on by your enthusiasm, Cale redoubles his lapping, raking his tongue over and inside your folds. Bit by bit, your movements grow more erratic, your swaying becoming wider. Pretty soon, the wolf only has to hold out his tongue, as you eagerly ride him, rubbing the entire length of your [vagDesc] on his face.", parse);
+		Text.Add("Moaning encouragingly, you start grinding your [hipsDesc] erratically, rubbing your cunt on the canine’s face. Spurred on by your enthusiasm, Cale redoubles his lapping, raking his flexible organ over and inside your folds. Bit by bit, your movements grow more inconsistent, your swaying becoming wider. Pretty soon, the wolf only has to hold out his tongue as you eagerly ride him, rubbing the entire length of your [vagDesc] on his face.", parse);
 		Text.NL();
 		parse["balls"] = player.HasBalls() ? " balls and" : "";
 		Text.Add("You start hearing muffled protests from Cale as you turn your grinding into long strokes, rubbing not only your cunt but also your[balls] [multiCockDesc] against him. Every time he grows too agitated, you let him have some more of your cooch before returning to grinding your shaft[s] on his mouth. Before long, he stops complaining altogether, and even starts to actively lick the undercarriage of your cock[s] when you present him with [itThem].", parse);
@@ -701,7 +702,7 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 		Text.Add("<i>“Suck,”</i> you repeat your previous command more forcefully, pinning him down. His will is faltering, and you can feel his tongue moving around uncertainly, inadvertently licking your [cockDesc]. To give him that extra push over the edge, your hand trails down his furry stomach to his stiff, crimson erection, insinuating that if he’s a good boy, maybe you’ll return the favor.", parse);
 		Text.NL();
 		if(virgin)
-			Text.Add("Cale lets out a muffled sigh as he capitulates, unable to resist the urges of his body. Closing his eyes in defeat as he allows you to have your way with him.", parse);
+			Text.Add("Cale lets out a muffled sigh as he capitulates, unable to resist the urges of his body. The wolf closes his eyes in defeat as he allows you to have your way with him.", parse);
 		else
 			Text.Add("If he needed any more motivation, that seems to have done it. No longer putting up even a semblance of resistance, he heartily starts sucking.", parse);
 	}
@@ -709,7 +710,7 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 		parse["slut"] = cale.Slut() < 30 ? " nervously" : "";
 		Text.Add("<i>“Woah, pent up, aren’t we,”</i> Cale chuckles[slut], getting down on his knees and prodding the offered dick[s] experimentally. Seeing [itThem] twitch in response, he grows bolder, grabbing[oneof] your [multiCockDesc] in his paw. A moan slips out of your lips as the wolf starts jerking you off. The soft skin on his palms feels really good on your sensitive flesh, but the main course has yet to come.", parse);
 		Text.NL();
-		Text.Add("Eager to get going, you place a [hand] on his shoulder, slowly pushing the wolf down on his back, erattically rubbing your [cockDesc] against his tight grip. ", parse);
+		Text.Add("Eager to get going, you place a [hand] on his shoulder, slowly pushing the wolf down on his back, erratically rubbing your [cockDesc] against his tight grip. ", parse);
 		if(cale.Slut() < 30)
 			Text.Add("<i>“Alright,”</i> Cale gulps, giving your shaft a tentative lick, sending a shiver up your spine. You let him take his time, stretching languidly while the wolf drags his tongue along the underside of your cock, lathering you up.", parse);
 		else
@@ -760,7 +761,7 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 		Text.Add("Before you’re even halfway done, the wolf is completely filled with your cum - mouth, throat and stomach. His eyes widen as he pats your [hipsDesc] urgently, pushing you off him before his belly inflates even further. Taking mercy on him, you pull out and let the rest of your load splash all over his face and body. When you are done, Cale looks like he is more cum than wolf, thoroughly painted white in your spunk. ", parse);
 	}
 	else if(cum > 3) {
-		Text.Add("Cale gets more than he bargained for, as your excessive load is enough to bloat the wolf’s belly to levels resembling pregnancy. When you finally pull out, the wolf is filled to the brim with cum, a slow trickle dribbling out his mouth. ", parse);
+		Text.Add("Cale gets more than he bargained for as your excessive load is enough to bloat the wolf’s belly to levels resembling pregnancy. When you finally pull out, the wolf is filled to the brim with cum, a slow trickle dribbling out his mouth. ", parse);
 	}
 	else {
 		Text.Add("Whether due to his horniness or from sheer surprise, Cale swallows your entire load, his eyes widening slightly as he feels the thick cream pouring down his throat. ", parse);
@@ -778,7 +779,7 @@ Scenes.Cale.SexGetBJSneakyEntry = function(outside, sneaky) {
 			Text.NL();
 			Text.Add("You ask him if it was really that bad.", parse);
 			Text.NL();
-			Text.Add("<i>“Well...”</i> he trails off thoughtfully. <i>“Don’t do it again I guess? Or at least return the favor some time, okay?”</i>", parse);
+			Text.Add("<i>“Well...”</i> he trails off thoughtfully. <i>“Don’t do it again, I guess? Or at least return the favor some time, okay?”</i>", parse);
 		}
 		
 		if(cale.Slut() < 30) {
@@ -863,14 +864,14 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 		Text.NL();
 	}
 	parse["legs"] = player.LowerBodyType() != LowerBodyType.Single ? " and spreading your legs" : "";
-	Text.Add("Swaying your [hipsDesc] seductively, you twirl around, showing him the goods. The wolf-morph all but jumps you, quickly tearing off your [lowerArmorDesc] and exposing your wet nether lips. You shy back for a brief second as he flashes his sharp teeth in a wide predatory smile. His long canine tongue is lolling hungrily, eager to dig in. The wolf looks like he could eat more than your pussy, given the chance. Still, you try to trust him and relax, reclining on your back[legs].", parse);
+	Text.Add("Swaying your [hipsDesc] seductively, you twirl around, showing him the goods. The wolf-morph all but jumps you, quickly tearing off your [lowerArmorDesc] and exposing your wet netherlips. You shy back for a brief second as he flashes his sharp teeth in a wide predatory smile. His long canine tongue is lolling hungrily, eager to dig in. The wolf looks like he could eat more than your pussy, given the chance. Still, you try to trust him and relax, reclining on your back[legs].", parse);
 	if(player.FirstCock())
 		Text.Add(" You pull your [multiCockDesc] out of the way, giving him full access to your crotch.", parse);
 	Text.NL();
 	
 	var scenes = new EncounterTable();
 	scenes.AddEnc(function() {
-		Text.Add("<i>“Just lie back and relax, and let this big bad wolf eat you up whole~”</i> Cale quips as he hovers over your spread labia, hot saliva dripping from his fangs on your [skinDesc].", parse);
+		Text.Add("<i>“Just lie back and relax, and let this big, bad wolf eat you up whole~”</i> Cale quips as he hovers over your spread labia, hot saliva dripping from his fangs on your [skinDesc].", parse);
 		Text.NL();
 	}, 1.0, function() { return true; });
 	scenes.AddEnc(function() {
@@ -878,7 +879,7 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 		Text.NL();
 	}, 1.0, function() { return true; });
 	scenes.AddEnc(function() {
-		Text.Add("<i>“Sure you don’t want a blowjob too? I don’t mind, and your little wolfie wants some meat~”</i> Cale coos, eying your equipment longingly. Relenting, you let him give your shaft[s] a few long licks, sating his craving for cock before he goes back to his original target.", parse);
+		Text.Add("<i>“Sure you don’t want a blowjob too? I don’t mind, and your little wolfie wants some meat~”</i> Cale coos, eyeing your equipment longingly. Relenting, you let him give your shaft[s] a few long licks, sating his craving for cock before he goes back to his original target.", parse);
 		Text.NL();
 		
 		player.AddLustFraction(0.3);
@@ -886,16 +887,16 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 	
 	scenes.Get();
 	
-	Text.Add("Wasting no further time, the wolf digs in, burying his snout in your crotch. You gasp as his flexible tongue forces its way inside your [vagDesc], lapping up your juices greedily. <i>“Wanna know why my tongue is so big? It is to...”</i> Cale murmurs, the rest of his pun muffled by your muff. You squirm as the vibrations spread into your nethers, the quaking setting off cascading spikes of pleasure racing up your spine.", parse);
+	Text.Add("Wasting no further time, the wolf digs in, burying his snout in your crotch. You gasp as his flexible muscle forces its way inside your [vagDesc], lapping up your juices greedily. <i>“Wanna know why my tongue is so big? It is to...”</i> Cale murmurs, the rest of his pun muffled by your muff. You squirm as the vibrations spread into your nethers, the quaking setting off cascading spikes of pleasure racing up your spine.", parse);
 	Text.NL();
 	
 	Sex.Cunnilingus(cale, player);
 	cale.Fuck(null, 2);
 	player.Fuck(null, 2);
 	
-	Text.Add("Letting him handle the reins, you close your eyes, basking in the ecstasy roused by the wolf’s experienced tongue. Rosalin has certainly given him plenty opportunity to practise at this. ", parse);
+	Text.Add("Letting him handle the reins, you close your eyes, basking in the ecstasy roused by the wolf’s experienced tongue. Rosalin has certainly given him plenty opportunity to practice at this. ", parse);
 	if(player.FirstCock()) {
-		Text.Add("Cale’s ministrations haven’t gone unnoticed by your [multiCockDesc] - roused by the intense feelings of his tongue eating out your cunt, the shaft[s] stand[notS] erect, bobbing proudly.", parse);
+		Text.Add("Cale’s ministrations haven’t gone unnoticed by your [multiCockDesc] - roused by the intense feelings of his flexible organ eating out your cunt, the shaft[s] stand[notS] erect, bobbing proudly.", parse);
 		if(cale.Slut() >= 30) {
 			Text.Add(" Not wanting to let [itThem] feel left out, the wolf wraps his paw around your[biggest] [cockDesc], stroking it sensuously.", parse);
 		}
@@ -929,12 +930,12 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 	}, 1.0, function() { return (cale.Slut() >= 30) || clitcock == null; });
 	scenes.AddEnc(function() {
 		parse["balls"] = player.HasBalls() ? Text.Parse(" and [ballsDesc]", parse) : "";
-		Text.Add("Despite Cale’s enthusiastic lapping, you feel him stray sometimes. Sneaking a few licks and kisses on your [multiCockDesc][balls]. You flick one of his triangular ears, chastising him for not focusing on his job.", parse);
+		Text.Add("Despite Cale’s enthusiastic lapping, you feel him stray sometimes. The wolf sneaks in a few licks and kisses on your [multiCockDesc][balls]. You flick one of his triangular ears, chastising him for not focusing on his job.", parse);
 		Text.NL();
 		parse["c"] = (player.NumCocks() > 1 || player.FirstCock().Size() > 75) ? " so much" : "";
 		Text.Add("<i>“Wolves are carnivores, you can’t expect me to hold myself back with[c] meat on display,”</i> he chuckles, sneaking a lick on the [cockTip] of[oneof] your [cockDesc].", parse);
 		Text.NL();
-		Text.Add("Well, if he’s a good boy and get you off, you might consider throwing him a bone later.", parse);
+		Text.Add("Well, if he’s a good boy and gets you off, you might consider throwing him a bone later.", parse);
 		Text.NL();
 		Text.Add("<i>“Deal!”</i> he exclaims, digging his way back into your muff.", parse);
 		Text.NL();
@@ -942,7 +943,7 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 	
 	scenes.Get();
 	
-	Text.Add("Pretty soon, it is impossible to hold your moans in. Reduced to a panting heap by Cale’s skilled tongue, you try to hold out as long as you can, but to no avail. The rough texture of his tongue against your folds just feels too good, not to mention the possibilities his impressive reach offers him.", parse);
+	Text.Add("Pretty soon, it is impossible to hold your moans in. Reduced to a panting heap by Cale’s skilled tongue, you try to hold out as long as you can, but to no avail. The rough texture of his flexible muscle against your folds just feels too good, not to mention the possibilities his impressive reach offers him.", parse);
 	Text.NL();
 	
 	var cum = player.OrgasmCum();
@@ -959,9 +960,9 @@ Scenes.Cale.SexGetEatenEntrypoint = function(outside) {
 		Text.Add(" Your [multiCockDesc] [isntArent] far behind, [cum1] the wolf with [itsTheir][cum2] load.", parse);
 		Text.NL();
 		if(cale.Slut() >= 60)
-			Text.Add("<i>“Mm… so tasty,”</i> he sighs as he laps up your cum, revelling in the taste.", parse);
+			Text.Add("<i>“Mm… so tasty,”</i> he sighs as he laps up your cum, reveling in the taste.", parse);
 		else if(cale.Slut() >= 30)
-			Text.Add("He greedily laps up your sticky offering, looking at you slightly guiltily.", parse);
+			Text.Add("He greedily laps up your sticky offering, looking at you somewhat guiltily.", parse);
 		else
 			Text.Add("He looks slightly irritated, wiping off the cum from his face, but he isn’t about to let a bit of semen ruin his mood.", parse);
 		Text.NL();
@@ -1023,7 +1024,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 		Text.Add("With Cale’s peculiar attributes, there is no need for additional lube. His hole is as ready for you as it’ll ever be. You remove your [lowerArmorDesc], itching to start pounding the wolf into oblivion.", parse);
 	else
 		Text.Add("As you fumble with your [lowerArmorDesc], you fish out a bottle of lube, pouring its contents on Cale’s tight[virgin] hole. He yips as the cool liquid splashes between his cheeks, shivering in anticipation of what's to come. You rub it in with your thumb, probing and teasing his anus.", parse);
-	Text.Add(" Once he’s ready, you pull out your[stiffening] [multiCockDesc], rubbing [itThem] in the sloppy lubricating mess between the wolf’s buttcheeks. Just to tease him even more, you grasp him by the hips, hotdogging your[artificial] shaft[s] and coating [itsTheir] length in the slippery liquid.", parse);
+	Text.Add(" Once he’s ready, you pull out your[stiffening] [multiCockDesc], rubbing [itThem] in the sloppy lubricating mess between the wolf’s butt cheeks. Just to tease him even more, you grasp him by the hips, hotdogging your[artificial] shaft[s] and coating [itsTheir] length in the slippery liquid.", parse);
 	Text.NL();
 	if(virgin)
 		Text.Add("<i>“I’ve changed my mind, I’ve changed my mind!”</i> he yips desperately, trying to scramble away but hindered by his pants wrapping around his knees.", parse);
@@ -1044,7 +1045,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 		Text.NL();
 		Text.Add("<i>“Do you like it?”</i> you tease him, shifting your [hipsDesc] slightly, sending another tremble through the paralyzed wolf.", parse);
 		Text.NL();
-		Text.Add("<i>“N-Of course not!”</i> he gasps defiantly, squirming under your gaze. A rather bad plan, considering his current position.", parse);
+		Text.Add("<i>“N-no, of course not!”</i> he gasps defiantly, squirming under your gaze. A rather bad plan, considering his current position.", parse);
 		Text.NL();
 		Text.Add("<i>“I know someone who disagrees with you,”</i> you whisper, reaching down between his furred legs to grasp his rock hard canid member, an erect monument of his confused sexuality. Merely touching it causes it to twitch, sending a splattering of pre onto the ground. Curious at his extreme reaction, you rock your hips slowly, sending another twitch through the crimson member.", parse);
 		Text.NL();
@@ -1064,7 +1065,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 	Text.Add("Starting out slow, you rock your [hipsDesc] back and forth, establishing a rhythm. Your [cockDesc] is glistening with moisture as you pull out, leaving only the [cockTip] inside Cale’s hole, making pushing it inside again all that much easier. With each slow, determined thrust, you bury yourself deeper and deeper inside the wolf, sighing in pleasure at the [real].", parse);
 	Text.NL();
 	if(cale.Slut() >= 60)
-		Text.Add("From his moans, you guess that the horny wolf has gone into heat again, but you know just the cure for that condition; a hot, deep dicking, applied roughly and repeatedly.", parse);
+		Text.Add("From his moans, you guess that the horny wolf has gone into heat again, but you know just the cure for that condition: a hot, deep dicking, applied roughly and repeatedly.", parse);
 	else
 		Text.Add("Soon, Cale falters, too overwhelmed by the sensations to offer more futile complaints. No matter how much he tries though, he is unable to stifle his increasingly loud moaning.", parse);
 	Text.NL();
@@ -1076,7 +1077,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 	Text.Add("The wolf pants for breath, letting out a lewd howl as a shudder goes through his entire body, his legs giving out. If he wasn’t already propped up by the convenient [log], he’d probably collapse. Reaching down to confirm your suspicion, you feel Cale’s rigid member twitching, the knot at the base twice his usual size.", parse);
 	Text.NL();
 	parse["hornyEmbarrassed"] = cale.Slut() >= 40 ? "horny" : "embarrassed";
-	Text.Add("<i>“Coming so soon? But I’ve barely gotten started,”</i> you say teasingly, never skipping a beat in your steady rhythm. Cupping your hand under his still fountaining cock, you gather a [hand]ful of his hot seed, presenting the sticky mess to the [hornyEmbarrassed] wolf.", parse);
+	Text.Add("<i>“Cumming so soon? But I’ve barely gotten started,”</i> you say teasingly, never skipping a beat in your steady rhythm. Cupping your hand under his still fountaining cock, you gather a [hand]ful of his hot seed, presenting the sticky mess to the [hornyEmbarrassed] wolf.", parse);
 	Text.NL();
 	if(cale.Slut() >= 60) {
 		Text.Add("Without hesitation, the slutty morph sticks out his tongue, lapping up his own seed from your outstretched [hand], cleaning it thoroughly. You egg him on encouragingly, praising him for being such a good bitch. You’ll make sure he gets more cum to drink down before long.", parse);
@@ -1087,7 +1088,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 		Text.Add("<i>“Ew, gross,”</i> he complains unconvincingly. You roll your eyes at his bad theatrics. He winces as you place your still sticky [hand] on his back, painting his dark fur white.", parse);
 	}
 	Text.NL();
-	Text.Add("The wolf’s long shaggy fur and fluffy tail provides excellent grasping points for you; not that he is going somewhere anytime soon. Even minutes later, he still looks completely spent from his first orgasm, moaning weakly as you rail him at an increasingly rough pace.", parse);
+	Text.Add("The wolf’s long, shaggy fur and fluffy tail provides excellent grasping points for you; not that he is going somewhere anytime soon. Even minutes later, he still looks completely spent from his first orgasm, moaning weakly as you rail him at an increasingly rough pace.", parse);
 	if(virgin)
 		Text.Add(" After this, there is no way he can dispute that he loves this new form of sex.", parse);
 	Text.NL();
@@ -1148,7 +1149,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 						Text.Add("<i>“Damn, that’s more than I shoot - hah - I feel so full,”</i> Cale whimpers as his stomach slowly swells from your massive amount of cum.", parse);
 					}
 					else {
-						Text.Add("<i>“Ah, you just had to come inside, did you?”</i> Cale whines as he feels your load splatter inside his well-used back door.", parse);
+						Text.Add("<i>“Ah, you just had to cum inside, did you?”</i> Cale whines as he feels your load splatter inside his well-used back door.", parse);
 					}
 				}
 				
@@ -1217,7 +1218,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					parse["dripsLeaksSplashes"] = cum > 6 ? "splashes" :
 					                              cum > 3 ? "leaks" :
 					                              "drips";
-					Text.Add(" When you do, the trapped remains of your [meagerHugeMassive] load [dripsLeaksSplashes] out of his gaping anus, dripping to the ground below.", parse);
+					Text.Add(" When you do, the trapped remains of your [meagerHugeMassive] load [dripsLeaksSplashes] out of his gaping anus, falling to the ground below.", parse);
 				}
 				Text.NL();
 				parse["cum"] = player.FirstCock() ? " both your and" : "";
@@ -1237,7 +1238,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					options.push({ nameStr : "Be forward",
 						func : function() {
 							Text.Clear();
-							Text.Add("Smirking to yourself, you nuzzle the wolf-morph, who visibly restrains himself from flinching. Your hand reaches around and presses itself gently against his stomach, feeling the soft fur. With slow, sensuous motions your fingers start to rub up and down, trailing the contour of his nicely muscled abs.", parse);
+							Text.Add("Smirking to yourself, you nuzzle the wolf-morph, who visibly restrains himself from flinching. Your hand reaches around and presses itself gently against his stomach, feeling the soft fur. With slow, sensuous motions, your fingers start to rub up and down, trailing the contour of his nicely muscled abs.", parse);
 							Text.NL();
 							Text.Add("As you continue stroking him, you casually ask what he was thinking about. You feign ignorance of his discomfort, but really you are drinking in every reaction, delight flooding you as you see the tip of his crimson member poke out from its sheath again.", parse);
 							Text.NL();
@@ -1246,13 +1247,13 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 							
 							Text.Add("He swallows audibly. <i>“I was thinking about what we did…”</i> he trails off. <i>“What <b>you</b> did to <b>me</b>,”</i> he adds, as if that wasn’t obvious. Just to mess with him, you nudge him in the back with your [multiCockDesc].", parse);
 							Text.NL();
-							Text.Add("You know he's not going to say he didn't like it, you declare, your hand slowly creeping downward, toward his loins. Enjoying every moment of it, you wrap a hand possessively around the warmth of his now-erect cock. Up and down you stroke him in slow, languid pumps, your thumb rubbing circles over his pointy, cum-soaked glans.", parse);
+							Text.Add("You know he's not going to say he didn't like it, you declare, your hand slowly creeping downward, toward his loins. Enjoying every moment of it, you wrap your fingers possessively around the warmth of his now-erect cock. Up and down, you stroke him in slow, languid pumps, your thumb rubbing circles over his pointy, cum-soaked glans.", parse);
 							Text.NL();
-							Text.Add("He moves his hip in tandem with your stroking, wary of disturbing your pace lest you stop your ministrations. He moans softly as he begins gyrating his hips. <i>“I didn’t… I mean, I didn’t say I didn’t like it,”</i> he replies, humping your hand softly. Considering the way his face is scrunching up in pleasure, you’d guess this simple handjob is feeling nearly as good as Rosalin’s pussy.", parse);
+							Text.Add("He thrusts in tandem with your stroking, wary of disturbing your pace lest you stop your ministrations. He moans softly as he begins gyrating his hips. <i>“I didn’t… I mean, I didn’t say I didn’t like it,”</i> he replies, humping your hand softly. Considering the way his face is scrunching up in pleasure, you’d guess this simple handjob is feeling nearly as good as Rosalin’s pussy.", parse);
 							Text.NL();
 							Text.Add("Smirking, you ask if he wants another go so soon after your last romp, rubbing your [cockDesc] against his back suggestively.", parse);
 							Text.NL();
-							Text.Add("<i>“I… kinda wish I could, but I’m spent,”</i> Cale sighs, shuddering as you keep jerking him off. <i>“I… hah… I’ve never felt like this before, not once…”</i> he trails off, moaning softly as you stroke him. In record time, another throb runs through the stiff cock in your hands as Cale’s third, significantly weaker orgasm splatters uselessly on the ground.", parse);
+							Text.Add("<i>“I… kinda wish I could, but I’m spent,”</i> Cale sighs, shuddering as you keep jerking him off. <i>“I… hah… I’ve never felt like this before, not once…”</i> he trails off, moaning softly as you stroke him. In record time, another throb runs through the stiff cock in your hands as Cale’s third, significantly weaker, orgasm splatters uselessly on the ground.", parse);
 							Text.NL();
 							Text.Add("<i>“J-just let me catch my breath,”</i> the wolf gasps, <i>“I need some rest before next time, okay?”</i> Though it is tempting to take him again then and there, you need some time to recover yourself, so you regretfully take mercy on him. At least he wants a next time...", parse);
 							
@@ -1281,7 +1282,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					options.push({ nameStr : "Comfort",
 						func : function() {
 							Text.Clear();
-							Text.Add("Smiling gently, you ask if he's alright, and apologise for how you treated him.", parse);
+							Text.Add("Smiling gently, you ask if he's alright, and apologize for how you treated him.", parse);
 							Text.NL();
 							Text.Add("He looks a bit surprised at the apology. <i>“Huh? Oh, right. Sure, no problem. It’s not like I didn’t enjoy it,”</i> he examines you, a bit unsure of himself. <i>“A bit, just a bit,”</i> he hurriedly adds.", parse);
 							Text.NL();
@@ -1337,13 +1338,13 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 						Text.NL();
 						Text.Add("Yeah, you and the satyr set it up. Is he really going to complain now though, of all times? The deed is done and you’ve already claimed your <i>just</i> reward.", parse);
 						if(cale.flags["maxPast"] > 0)
-							Text.Add(" Plus, you thought he was a more ‘in the moment’ kind of guy.", parse);
+							Text.Add(" Plus you thought he was a more ‘in the moment’ kind of guy.", parse);
 						Text.NL();
-						Text.Add("<i>“Oh, I’m not really mad at you. Sure it was underhanded of you, but honestly? I should’ve seen it coming. So this one is on me, for not keeping an eye out for cheating. Serves me right.”</i>", parse);
+						Text.Add("<i>“Oh, I’m not really mad at you. Sure, it was underhanded of you, but honestly? I should’ve seen it coming. So this one is on me, for not keeping an eye out for cheating. Serves me right.”</i>", parse);
 						Text.NL();
 						Text.Add("...That’s a bit surprising, you imagined he’d be a bit more of a sore loser once he figured out you cheated your way into his butt.", parse);
 						Text.NL();
-						Text.Add("<i>“Make no mistake, sore describes my situation pretty accurately right now,”</i> he says, rubbing his butt. <i>“But, if I may be so honest, I’m kinda flattered you thought you had to cheat your way into winning,”</i> he says, grinning confidently. <i>“Hope you enjoyed your victory, cuz next time I’mma keep an eye out and catch you red-handed.”</i>", parse);
+						Text.Add("<i>“Make no mistake, sore describes my situation pretty accurately right now,”</i> he says, rubbing his butt. <i>“But if I may be honest, I’m kinda flattered you thought you had to cheat your way into winning,”</i> he says, grinning confidently. <i>“Hope you enjoyed your victory, 'cuz next time I’mma keep an eye out and catch you red-handed.”</i>", parse);
 						Text.NL();
 						Text.Add("Those are fighting words. Alright then, challenge accepted. You’ll just have to find new ways of winning.", parse);
 					}
@@ -1356,12 +1357,12 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 							Text.Add("The excuses of a wolf-slut, you sigh. He’s not even trying to hide it anymore, not that you mind seeing him brazenly admit his fetishes.", parse);
 						}
 						else {
-							Text.Add("<i>“Umm… I… got a bit distracted. Y’see I’ve been drinking and I guess I’m still a bit sluggish.”</i>", parse);
+							Text.Add("<i>“Umm… I… got a bit distracted. Y’see, I’ve been drinking and I guess I’m still a bit sluggish.”</i>", parse);
 							Text.NL();
-							Text.Add("You roll your eyes. At this point you’re not sure if he’s trying to lie to you or himself. In either case, it matters not. You both know he enjoyed that, and if he doesn’t want to get his butt reamed, all he has to do is say <i>no</i> next time you challenge him.", parse);
+							Text.Add("You roll your eyes. At this point, you’re not sure if he’s trying to lie to you or himself. In either case, it matters not. You both know he enjoyed that, and if he doesn’t want to get his butt reamed, all he has to do is say <i>no</i> next time you challenge him.", parse);
 						}
 						Text.NL();
-						Text.Add("<i>“Next time I’ll show ya. Got a few tricks up my sleeve.”</i> He rubs his paws together, smiling mischievously.", parse);
+						Text.Add("<i>“Next time, I’ll show ya. Got a few tricks up my sleeve.”</i> He rubs his paws together, smiling mischievously.", parse);
 						Text.NL();
 						if(cale.flags["cLoss"] >= 5) {
 							Text.Add("Considering his track record? You seriously doubt that. You half-expect the wolf to admit he’d rather jump to the part where you dig your way into his [cAnusDesc] than continue this charade. For now though, you think you’ll humor him.", parse);
@@ -1376,7 +1377,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					if(virgin) {
 						Text.Add("So, how did he feel about his first anal fuck?", parse);
 						Text.NL();
-						Text.Add("<i>“I… Uh, not sure, to be honest.”</i> The wolf looks confused about the whole ordeal.", parse);
+						Text.Add("<i>“I… uh, not sure, to be honest.”</i> The wolf looks confused about the whole ordeal.", parse);
 						Text.NL();
 					}
 				}
@@ -1386,7 +1387,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					if(cale.Slut() >= 30)
 						Text.Add("You ask if he’s sure he didn’t lose on purpose? It sure looked like he bet his ass on some really weak hands… The wolf flashes you a quick grin. <i>“Well, it’s no big deal if I lose, and winning has a whole lot of perks to it.”</i>", parse);
 					else
-						Text.Add("Was it really that bad tho? <i>“I got what I deserved, I guess,”</i> he grimaces. <i>“Shouldn’t have bet on that one hand, but I thought I really had you there. Besides, folding wouldn’t have made things any better.”</i>", parse);
+						Text.Add("Was it really that bad though? <i>“I got what I deserved, I guess,”</i> he grimaces. <i>“Shouldn’t have bet on that one hand, but I thought I really had you there. Besides, folding wouldn’t have made things any better.”</i>", parse);
 					Text.NL();
 					if(cale.flags["cLoss"] <= 1) {
 						Text.Add("<i>“Tell me though, how come you didn’t pick Rosie?”</i>", parse);
@@ -1400,7 +1401,7 @@ Scenes.Cale.SexFuckHim = function(outside, opts) {
 					if(virgin) {
 						Text.Add("So, how did he feel about his first anal fuck?", parse);
 						Text.NL();
-						Text.Add("<i>“I… Uh, not sure, to be honest.”</i> The wolf looks confused about the whole ordeal.", parse);
+						Text.Add("<i>“I… uh, not sure, to be honest.”</i> The wolf looks confused about the whole ordeal.", parse);
 						Text.NL();
 					}
 				}
@@ -1431,11 +1432,11 @@ Scenes.Cale.SexCatchVag = function(outside) {
 	
 	Text.Clear();
 	if(cale.Slut() < 60)
-		Text.Add("<i>“Music to my ears.”</i> he says already starting to undo his pants.", parse);
+		Text.Add("<i>“Music to my ears,”</i> he says, already starting to undo his pants.", parse);
 	else
 		Text.Add("<i>“Feel like some wolf cock after all the wolf butt you got? I can oblige!”</i> he says, grinning happily as he begins stripping.", parse);
 	Text.NL();
-	Text.Add("Needing no further encouragement yourself, you start to strip as well, placing your gear side so it’s not likely to get messy or kicked away. By the time you’re finished, Cale is naked and seated with his legs sprawled open, letting you watch him jiggling and stroking his balls, a half-erect wolf-cock bobbing above his sheathe at the motions.", parse);
+	Text.Add("Needing no further encouragement yourself, you start to strip as well, placing your gear side so it’s not likely to get messy or kicked away. By the time you’re finished, Cale is naked and seated with his legs sprawled open, letting you watch him jiggling and stroking his balls, a half-erect wolf-cock bobbing above his sheath at the motions.", parse);
 	Text.NL();
 	Text.Add("<i>“How about helping me get prepped for the taking?”</i> He suggests.", parse);
 	Text.NL();
@@ -1447,14 +1448,14 @@ Scenes.Cale.SexCatchVag = function(outside) {
 	options.push({ nameStr : "Handjob",
 		func : function() {
 			Text.Clear();
-			Text.Add("With a grin, you saunter toward him and kneel down before him, gently but insistently pushing his hands away before wrapping your own fingers around his dick. The warm semi-turgid flesh pulses gently against your [skinDesc] as you start to rhythmically stroke up and down. You squeeze and release as you go, alternating the pressure in time with your strokes, sliding Cale’s wolfhood through your fingers and across your palm before glancing up and seeing how he’s enjoying this.", parse);
+			Text.Add("With a grin, you saunter toward him and kneel down before him, gently but insistently pushing his hands away before wrapping your own fingers around his dick. The warm, semi-turgid flesh pulsates gently in your grip as you start to rhythmically stroke up and down. You squeeze and release as you go, alternating the pressure in time with your motions, sliding Cale’s wolfhood through your digits and across your palm before glancing up and seeing how he’s enjoying this.", parse);
 			Text.NL();
 			Text.Add("<i>“Yeah… touch my balls too. Get me nice and hard for you,”</i> he says, beginning to pant.", parse);
 			Text.NL();
-			Text.Add("With your free hand, you do as asked, rolling and kneading the full, fluffy orbs against your palm. You can feel his shaft growing harder in your hand, a distinctive roundness at its base signalling his knot coming into play; it’s still deflated, but you and he both know it’s already aching to be used. As wetness starts to dampen your fingers, you smile to yourself, playfully making an idle comment to Cale about him leaking precum already. You keep stroking, letting his fluids seep over your fingers until they drip with it, and then let him go.", parse);
+			Text.Add("With your free hand, you do as asked, rolling and kneading the full, fluffy orbs against your palm. You can feel his shaft growing harder in your grasp, a distinctive roundness at its base signaling his knot coming into play; it’s still deflated, but you and he both know it’s already aching to be used. As wetness starts to dampen your fingers, you smile to yourself, playfully making an idle comment to Cale about him leaking pre-cum already. You keep stroking, letting his fluids seep over your digits until they drip with it, and then let him go.", parse);
 			Text.NL();
 			if(player.Slut() >= 25) {
-				Text.Add("Holding your hand up so that Cale’s precum glistens on your fingers, you grin at him as you roll it gently back and forth before lifting your palm to your face and starting to lap it clean with your tongue. Eyes half-hooded in desire, you slowly clean your fingers off, noisily sucking them clean until you’ve licked up every drop.", parse);
+				Text.Add("Holding your hand up so that Cale’s pre-cum glistens on your fingers, you grin at him as you roll it gently back and forth before lifting your palm to your face and starting to lap it clean with your tongue. Eyes half-hooded in desire, you slowly clean your digits off, noisily sucking on them until you’ve licked up every drop.", parse);
 				Text.NL();
 				Text.Add("Cale swallows audibly, and you think you see his cock throb at the sight. <i>“Damn if you don’t know how to get a guy going, [playername]...”</i> he says in admiration.", parse);
 			}
@@ -1466,7 +1467,7 @@ Scenes.Cale.SexCatchVag = function(outside) {
 			Text.NL();
 			Text.Add("Cale motions to the [log] beside the two of you. <i>“Get comfy and we can get started then.”</i>", parse);
 			Text.NL();
-			Text.Add("Glancing at the [log], you look back at him and shake your head; you have a different position in mind. You tell him to lay back and get comfortable. Cale tilts his head, looking a little bemused, but shrugs his shoulders and complies readily enough. Rising up, you move to straddle his waist, repositioning him slightly so he’ll be more comfortable, slowly dropping your way down his belly so he fully understands what it is you intend to do, halting just before he can penetrate you.", parse);
+			Text.Add("Glancing at the [log], you look back at him and shake your head; you have a different position in mind. You tell him to lie back and get comfortable. Cale tilts his head, looking a little bemused, but shrugs his shoulders and complies readily enough. Rising up, you move to straddle his waist, repositioning him slightly so he’ll be more comfortable, slowly dropping your way down his belly so he fully understands what it is you intend to do, halting just before he can penetrate you.", parse);
 			Text.NL();
 			
 			Scenes.Cale.SexCatchVagEntrypoint(outside);
@@ -1476,15 +1477,15 @@ Scenes.Cale.SexCatchVag = function(outside) {
 	options.push({ nameStr : "Blowjob",
 		func : function() {
 			Text.Clear();
-			Text.Add("Smirking seductively, you sashay your way over to Cale and kneel with exaggeratedly demure motions before him. You slowly run your tongue over your lips in a tantalising motion that makes the wolf move his hands, allowing you to lower your [faceDesc] toward his groin.", parse);
+			Text.Add("Smirking seductively, you sashay your way over to Cale and kneel with exaggeratedly demure motions before him. You slowly run your tongue over your lips in a tantalizing motion that makes the wolf move his hands, allowing you to lower your [faceDesc] toward his groin.", parse);
 			Text.NL();
-			Text.Add("Your [tongueDesc] glides out and then slowly strokes up his half-erect shaft, starting just above his sheathe and moving up to his tip. You circle his glans with the tip of your tongue, then release him before applying your tip back at his base and gliding up again, smooth even strokes up and down.", parse);
+			Text.Add("Your [tongueDesc] glides out and then slowly strokes up his half-erect shaft, starting just above his sheath and moving up to his tip. You circle his glans with the tip of your tongue, then release him before applying your [tongueTip] back at his base and gliding up again, smooth, even strokes up and down.", parse);
 			Text.NL();
 			Text.Add("<i>“Shit! Just don’t go overboard on it. Don’t wanna disappoint and cum before I’ve had a chance at your pussy.”</i>", parse);
 			Text.NL();
-			Text.Add("You keep that thought in mind, but you’re not done with him yet. You let your tongue trail back down his shaft, licking at the base of his sheath as best you can before moving down to lap at his balls. You trace patterns over them with your tongue-tip, then glide your way back up to his now-dribbling tip, sucking gently at it and letting his precum wash over your senses. When you pull your mouth away, Cale’s cock is sticking out like an accusing finger, pointing straight between your eyes, almost visibly throbbing in arousal.", parse);
+			Text.Add("You keep that thought in mind, but you’re not done with him yet. You let your tongue trail back down his shaft, licking at the base of his sheath as best you can before moving down to lap at his balls. You trace patterns over them with your tongue-tip, then glide your way back up to his now-dribbling tip, sucking gently at it and letting his pre-cum wash over your senses. When you pull your mouth away, Cale’s cock is sticking out like an accusing finger, pointing straight between your eyes, almost visibly throbbing in arousal.", parse);
 			Text.NL();
-			Text.Add("<i>“I’m almost sad that you stopped, almost. Now the main course aye?”</i> You nod. <i>“Alright, bend over this [log] yonder, m’lady.”</i> He makes a flourish at the [log] beside the two of you.", parse);
+			Text.Add("<i>“I’m almost sad that you stopped, almost. Now the main course, aye?”</i> You nod. <i>“Alright, bend over this [log] yonder, m’lady.”</i> He makes a flourish at the [log] beside the two of you.", parse);
 			Text.NL();
 			Text.Add("You shake your head with a smile; nope, that’s not how it’s going to work. Standing up, you place a gentle hand on his shoulders and guide him into leaning back against the [log], maneuvering to straddle his waist, your hands still on his shoulders, grinning as you look right into his eyes. As if he needs further explanation of what you have in mind, you start to bend down, resting more of your weight on him, sliding down his trim belly until he can just barely feel the heat of your aroused womanhood on the head of his dick.", parse);
 			Text.NL();
@@ -1503,22 +1504,22 @@ Scenes.Cale.SexCatchVag = function(outside) {
 				var biggestCock = player.BiggestCock();
 				if(biggestCock) {
 					parse["cockBiggestDesc"] = function() { return biggestCock.Short(); }
-					Text.Add("Curling your thumb and forefinger into a circular pattern, you reach for your [cockBiggestDesc] and slide its glans through the hole of your palm, squeezing softly as you trail down its length until your hand is resting against your groin. You twist your wrist slightly, pulling back against your shaft, and then curl your other hand around your shaft in the same manner, pulling back up your member to your glans.", parse);
+					Text.Add("Curling your thumb and forefinger into a circular pattern, you reach for your [cockBiggestDesc] and slide its glans through the hole of your palm, squeezing softly as you trail down its length until your [hand] is resting against your groin. You twist your wrist slightly, pulling back against your shaft, and then curl your other hand around your cock in the same manner, pulling back up your member to your glans.", parse);
 					Text.NL();
 					parse["s"] = player.NumCocks() > 1 ? "s" : "";
-					Text.Add("Your skin tickles at the friction, blood rushing into your shaft[s] as you repeat the milking motion again with your first hand, the second hand taking its place around the base of your dick. With smooth, even strokes you rhythmically pull and stroke, moaning softly in your arousal, eyes hooded in lust as you glance at your wolfy slut and see if he’s enjoying the show.", parse);
+					Text.Add("Your skin tickles at the friction, blood rushing into your shaft[s] as you repeat the milking motion again with your first [hand], the second [hand] taking its place around the base of your dick. With smooth, even strokes, you rhythmically pull and stroke, moaning softly in your arousal, eyes hooded in lust as you glance at your wolfy slut and see if he’s enjoying the show.", parse);
 				}
 				else {
 					Text.Add("Adjusting the straps around your loins to make sure it’s properly fixed, you grab your prosthetic [multiCockDesc] and slot it home, checking to see that it’s set properly with slow, purposeful motions. Once satisfied that it’s secure, you smirk at Cale and begin to caress the faux-dick with your fingers, a lewd groan of appreciation bubbling from your lips as they dance up and down across the dildo’s length, acting as if you can truly feel yourself upon the imitation phallus.", parse);
 				}
 				Text.NL();
-				Text.Add("Cale watches the spectacle unfold, tongue lolling out as he pants and strokes his own cock with a hand. His other hand is busy teasing his entrance. The slutty wolf lets out a wanton moan as he finally pierces his tight ring with his middle fingers, masturbating himself as he dreams of your [multiCockDesc] entering him.", parse);
+				Text.Add("Cale watches the spectacle unfold, tongue lolling out as he pants and strokes his own cock with a hand. His other hand is busy teasing his entrance. The slutty wolf lets out a wanton moan as he finally pierces his tight ring with his middle fingers, masturbating as he dreams of your [multiCockDesc] entering him.", parse);
 				Text.NL();
 				Text.Add("<i>“Damn, [playername]. That’s playing dirty, teasing me with the promise of buttsex,”</i> he says, stifling a moan as he wills himself to stop masturbating. His cock is already throbbing at full mast, the veins bulging out as a droplet of pre slides down his length.", parse);
 				Text.NL();
 				Text.Add("Maybe so, you concede, but it certainly got him in the mood, now didn’t it? Now, you’ve a hungry pussy here just waiting for some stuffing of its own; if he does a good job, you’ll see about stuffing his ass in turn, you promise.", parse);
 				Text.NL();
-				Text.Add("<i>“Deal! Now why don’t you see about settling on that [log]-”</i> You stop him with a finger on his lips. Smiling, you shake your head and move to take his shoulders, pushing him down and leaning him back against the [log] before moving to straddle him. Deliberately letting your [multiCockDesc] rest against his chest, you grind your hips into his torso and slowly glide down, until your [vagDesc] is hovering just above his hot erection.", parse);
+				Text.Add("<i>“Deal! Now, why don’t you see about settling on that [log]-”</i> You stop him with a finger on his lips. Smiling, you shake your head and move to take his shoulders, pushing him down and leaning him back against the [log] before moving to straddle him. Deliberately letting your [multiCockDesc] rest against his chest, you grind your hips into his torso and slowly glide down until your [vagDesc] is hovering just above his hot erection.", parse);
 				Text.NL();
 				
 				Scenes.Cale.SexCatchVagEntrypoint(outside);
@@ -1563,7 +1564,7 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 		else {
 			Text.Add("<i>“Aw, [playername]. Now you’re just spoiling me,”</i> he says, batting his eyes teasingly at you.", parse);
 			Text.NL();
-			Text.Add("Grinning back, you reach out and gently pat his head, assuring him that only the best is good enough for your favorite wolf. Your grin widens as you hear an arrhythmic thumping noise; Cale’s tail is wagging so hard he’s drumming on the [log] behind him.", parse);
+			Text.Add("Grinning back, you reach out and gently pat his head, assuring him that only the best is good enough for your favorite wolf. Your grin widens as you hear an arrhythmic thumping noise; Cale’s tail is wagging so hard that he’s drumming on the [log] behind him.", parse);
 		}
 		Text.NL();
 		Text.Add("Now that the foreplay is over with, it’s time to have some real fun. With a final breath, you finish your descent, allowing his cock to close the distance between you and push into your folds. The feeling of him spearing into your needy [vagDesc] sends jolts of both pain and pleasure coursing throughout your body. A groan escapes your throat at the stimulus, only enticing you to sink yourself downward further, refusing to stop until you have reached to just above his knot.", parse);
@@ -1576,20 +1577,20 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 	
 	Text.Add("Cale’s hands immediately fly to your hips, and you can see his muscles tense as he works to lift you.", parse);
 	Text.NL();
-	Text.Add("You push with your [legsDesc], helping Cale to lift you up and down, your breath coming in short pants as you feel his fat dick grinding away inside of you with each rise and fall. Your [vagDesc] clamps down as you rise up his length, clenching him as best you can to make it as hard as possible to remove you, slackening only when gravity starts to bring you back down to delicious fullness.", parse);
+	Text.Add("You push with your [legsDesc], helping Cale to lift you up and down, your breathing coming in short pants as you feel his fat dick grinding away inside of you with each rise and fall. Your [vagDesc] clamps down as you rise up his length, clenching him as best you can to make it as hard as possible to remove you, slackening only when gravity starts to bring you back down to delicious fullness.", parse);
 	Text.NL();
-	Text.Add("It doesn’t take long for you to feel Cale’s cold nose bumping against your [nipDesc], he begins licking you slowly and carefully.", parse);
+	Text.Add("It doesn’t take long for you to feel Cale’s cold nose bumping against your [nipDesc], and he begins licking you slowly and carefully.", parse);
 	if(player.Lactation())
-		Text.Add(" When a droplet of your milk touches his tongue, he simply chuckles and envelops your nipple in his wolfish muzzle, and begins draining your [breastsDesc] of their precious milk.", parse);
+		Text.Add(" When a droplet of your milk touches his tongue, he simply chuckles and envelops your nipple in his wolfish muzzle, and begins draining your [breastsDesc] of their precious cream.", parse);
 	Text.NL();
 	
 	if(outside)
 		Scenes.Cale.SexGettingFuckedOutsideComments();
 	
-	Text.Add("Your excitement building, you don’t even think before upping the pace, lifting and falling with greater enthusiasm until your hips are audibly slapping against his own. Lust and pleasure chase each other through your brain, clouding your vision - but you don’t need eyes to feel that Cale is similarly lost in his pleasure. You can feel his knot, fat and swollen with his arousal, beating against your netherlips with each descent you make, so swollen it’s almost too big to freely slip in and out anymore.", parse);
+	Text.Add("Your excitement building, you don’t even think before upping the pace, lifting and falling with greater enthusiasm until your hips are audibly slapping against his own. Lust and pleasure chase each other through your brain, clouding your vision - but you don’t need eyes to feel that Cale is similarly lost in his reverie. You can feel his knot, fat and swollen with his arousal, beating against your netherlips with each descent you make, so engorged that it’s almost too big to freely slip in and out anymore.", parse);
 	Text.NL();
 	if((cale.Slut() >= 60) && cock && (cock.length.Get() >= 20)) {
-		Text.Add("The sight of your cock bobbing in front of him is too much for the slutty wolf. Without nary a second thought, he leans into your bobbing mast of manflesh and begins lavishing your [cockTip] with licks from his broad tongue.", parse);
+		Text.Add("The sight of your cock bouncing in front of him is too much for the slutty wolf. Without nary a second thought, he leans into your bobbing mast of manflesh and begins lavishing your [cockTip] with licks from his broad tongue.", parse);
 		Text.NL();
 		Text.Add("You moan unthinkingly as Cale starts to suck your dick. ", parse);
 		if(player.FirstCock())
@@ -1606,21 +1607,21 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 	
 	Text.Add("It’s all too much to hold onto anymore, and you echo Cale’s cry with one of your own as you climax, feminine fluids drooling down his shaft and over his balls.", parse);
 	if(player.FirstCock()) {
-		Text.Add(" Your shaft follows your womanhood in erupting, sending streamers of lady-spunk flying through the air toward Cale’s chest and face. ", parse);
+		Text.Add(" Your cock[s] follow[notS] your womanhood in erupting, sending streamers of lady-spunk flying through the air toward Cale’s chest and face. ", parse);
 		if(cum > 6) {
-			Text.Add("Thick and furious your geyser of semen flies, drenching Cale from head to belly in your spooge, painting him semen-white before you finish. ", parse);
+			Text.Add("Thick and furious your geyser of semen flies, drenching the wolf from head to belly in your spooge, painting him semen-white before you finish. ", parse);
 			if(cale.Slut() >= 60)
-				Text.Add("Cale opens his mouth eagerly, gulping down the flying feast of seed being blasted all over his face, swallowing until his stomach protests enough to make him settle for simply revelling in his perverse shower.", parse);
+				Text.Add("Cale opens his mouth eagerly, gulping down the flying feast of seed being blasted all over his face, swallowing until his stomach protests enough to make him settle for simply reveling in his perverse shower.", parse);
 			else
 				Text.Add("Face screwed up in a grimace, Cale accepts the torrential bath with discontent, trying desperately to keep from swallowing anything as best he can.", parse);
 		}
 		else if(cum > 3) {
-			Text.Add("Great ropes of white smear themselves over Cale’s face, drooling down to paint his neck and shoulders in more of the same.", parse);
+			Text.Add("Great ropes of white smear themselves over the wolf-morph’s face, drooling down to paint his neck and shoulders in more of the same.", parse);
 			if(cale.Slut() >= 60)
 				Text.Add(" He opens his mouth, trying to catch some of the flying treat, playfully catching as much of it as he can.", parse);
 		}
 		else {
-			Text.Add("Pearly strands paint themselves over Cale’s cheeks and throat.", parse);
+			Text.Add("Pearly strands paint themselves over the wolf’s cheeks and throat.", parse);
 			if(cale.Slut() >= 60)
 				Text.Add(" His tongue unthinkingly darts out to lap some up with a lewd slurp.", parse);
 		}
@@ -1629,7 +1630,7 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 	
 	var scenes = new EncounterTable();
 	scenes.AddEnc(function() {
-		Text.Add("<i>“Fuck! I’m gonna blow! Quick, [playername]. Can I knot or not?”</i> he asks, panting in desperation.", parse);
+		Text.Add("<i>“Fuck! I’m gonna blow! Quick, [playername], can I knot or not?”</i> he asks, panting in desperation.", parse);
 		Text.Flush();
 		
 		//[Yes] [No]
@@ -1637,14 +1638,14 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 		options.push({ nameStr : "Yes",
 			func : function() {
 				Text.Clear();
-				Text.Add("Cale’s thrusts increase in potency, each slap loosening you just a tiny bit as he works to force that huge knot of his inside. With a triumphant howl, he finally pops it inside and proceeds to dump his considerable load inside you.", parse);
+				Text.Add("Cale’s thrusts increase in potency, each slap loosening you just a tiny bit as he works to force that huge knot of his inside. With a triumphant howl, he finally pops it in and proceeds to dump his considerable load within you.", parse);
 				Text.NL();
 				
 				Scenes.Cale.Impregnate(player, PregnancyHandler.Slot.Vag, 4);
 				
-				Text.Add("You cry out, deep and low as you feel his thick knot forcing its way through your netherlips, blindly clamping down to wring every last drop from his balls, grinding his knot with the walls of your cunt. Liquid warmth bubbles and seethes inside of you as his seed races up, the seal of his knot so tight that his sperm has nowhere to go but inside your womb, your stomach visibly bulging before he shudders and goes slack.", parse);
+				Text.Add("You cry out, deep and low, as you feel his thick knot forcing its way through your netherlips, blindly clamping down to wring every last drop from his balls, grinding his bulbous flesh with the walls of your cunt. Liquid warmth bubbles and seethes inside of you as his seed races up, the seal of his bulb so tight that his sperm has nowhere to go but inside your womb, your stomach visibly bulging before he shudders and goes slack.", parse);
 				Text.NL();
-				Text.Add("Cale collapses, tongue lolling out as he groans due to his recent activities. His knot pulling to lay atop him. <i>“Damn, [playername]. Hell of a pussy you’ve got there,”</i> he compliments you with a lopsided grin.", parse);
+				Text.Add("Cale collapses, tongue lolling out as he groans due to his recent activities, his knot pulling to lay atop him. <i>“Damn, [playername]. Hell of a pussy you’ve got there,”</i> he compliments you with a lopsided grin.", parse);
 				if(cale.Slut() >= 60)
 					Text.Add(" <i>“Between this and getting a hard cock up my arse, I dunno what feels better.”</i>", parse);
 				Text.NL();
@@ -1677,13 +1678,13 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 		options.push({ nameStr : "No",
 			func : function() {
 				Text.Clear();
-				Text.Add("Cale’s thrust double in speed as he becomes a blur, trying his best to not let his knot slip into your used [vagDesc].  With a triumphant howl, the wolf cums! Spurt after spurt of his lupine spunk painting your walls white, even as some of his copious load escapes your entrance to drench his knot and balls. You can feel him throbbing inside, his hips still moving, or perhaps just trembling, in pleasure until he finally collapses in a panting heap of satisfied wolf.", parse);
+				Text.Add("Cale’s thrust double in speed as he becomes a blur, trying his best to not let his knot slip into your used [vagDesc]. With a triumphant howl, the wolf cums! Spurt after spurt of his lupine spunk painting your walls white, even as some of his copious load escapes your entrance to drench his knot and balls. You can feel him throbbing inside, his hips still moving, or perhaps just trembling, in pleasure until he finally collapses in a panting heap of satisfied wolf.", parse);
 				Text.NL();
 				
 				Scenes.Cale.Impregnate(player, PregnancyHandler.Slot.Vag, 2);
 				
 				parse["cum"] = cum > 3 ? " cum-slickened" : "";
-				Text.Add("With a great heaving sigh of satisfaction, you allow yourself to slowly sink atop him, cuddling him like a fluffy[cum] pillow as you rest on his form, bathing in your own warm glow of pleasure. Cheek to cheek you nuzzle him softly, content to lay here until you feel like your [legsDesc] won’t just give if you try to stand.", parse);
+				Text.Add("With a great heaving sigh of satisfaction, you allow yourself to slowly sink atop him, cuddling him like a fluffy[cum] pillow as you rest on his form, bathing in your own warm glow of pleasure. Cheek to cheek, you nuzzle him softly, content to lie here until you feel like your [legsDesc] won’t just give if you try to stand.", parse);
 				Text.Flush();
 				
 				Gui.NextPrompt(function() {
@@ -1713,9 +1714,9 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 			Text.NL();
 			Text.Add("<i>“Think I’d like to try another hole.”</i>", parse);
 			Text.NL();
-			Text.Add("Giving him a slightly dopey grin, you nod and assure him that you’re okay with that idea; you feel far too good to protest the idea of more Sex. Add in that Cale hasn’t cum yet, and, well, that’s even more reason.", parse);
+			Text.Add("Giving him a slightly dopey grin, you nod and assure him that you’re okay with that idea; you feel far too good to protest the idea of more sex. Add in that Cale hasn’t cum yet and, well, that’s even more reason.", parse);
 			Text.NL();
-			Text.Add("When the wolf attempts to lift you from his lap, you comply as well as you can, using his shoulders to help rise out of his lap. Your [legsDesc] are still too wobbly to have a hope of standing up, but that’s alright; it doesn’t seem like Cale has any plans to move too far, as he helps you to sprawl across the [log] behind him.", parse);
+			Text.Add("When the wolf attempts to lift you from his lap, you comply as well as you can, using his shoulders to help rise out of his lap. Your [legsDesc] [isAre] still too wobbly to have a hope of standing up, but that’s alright; it doesn’t seem like Cale has any plans to move too far as he helps you to sprawl across the [log] behind him.", parse);
 			Text.NL();
 			Text.Add("Once you are properly positioned to his liking, he gives your shoulder a friendly pat and moves behind you, where you can feel his hands coming down to rest on your ass.", parse);
 			Text.NL();
@@ -1724,20 +1725,20 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 			if(player.HasPrehensileTail()) {
 				Text.Add("You roll your eyes in exaggerated annoyance; does he have to always throw around those cheesy lines of his? Your [tailDesc] flicks around in a half-playful reprimand to slap his cheek, firmly enough that he can feel it, yet not so hard as to actually hurt him.", parse);
 				Text.NL();
-				Text.Add("<i>“Hey!”</i> he protests weakly at your tail-slap.", parse);
+				Text.Add("<i>“Hey!”</i> he protests weakly at your tail slap.", parse);
 			}
 			else
 				Text.Add("You don’t even bother trying to hide the fact you are rolling your eyes, heaving an exaggerated sigh at hearing yet another lame line of his. Doesn’t he have any better material than that?", parse);
 			Text.NL();
-			Text.Add("Clicking your tongue in the iconic tsk-tsk noise, you teasingly ask if he really has to use those same corny lines all the time. If he’s going to be that lame that he has to keep yapping like that, well, then you’re done - you got what you wanted, after all. Smirking to yourself, you start to push yourself up off of the [log] with your arms, as if you’re intent on rising to your [feetDesc] and leaving.", parse);
+			Text.Add("Clicking your tongue in the iconic 'tsk-tsk' noise, you teasingly ask if he really has to use those same corny lines all the time. If he’s going to be that lame that he has to keep yapping like that, well, then you’re done - you got what you wanted, after all. Smirking to yourself, you start to push yourself up off of the [log] with your arms as if you're intending to rise to your [feetDesc] and leave.", parse);
 			Text.NL();
 			parse["dudelady"] = player.mfTrue("dude", "lady");
-			Text.Add("<i>“W-wait, I’m not done yet!”</i> He grasps your [buttDesc] firmly holding you in position. <i>“Hold on there [dudelady]. Geez, no need to be so pushy, never heard of foreplay?”</i> he teases.", parse);
+			Text.Add("<i>“W-wait, I’m not done yet!”</i> He grasps your [buttDesc], firmly holding you in position. <i>“Hold on there, [dudelady]. Geez, no need to be so pushy; never heard of foreplay?”</i> he teases.", parse);
 			Text.NL();
 			Text.Add("You wouldn’t call what he was doing foreplay, you promptly shoot back. You have higher standards than that, you declare, a playful smirk on your lips.", parse);
 			Text.NL();
 			if(player.HasPrehensileTail()) {
-				Text.Add("<i>“...somehow that hurts a lot more than the tail-slap you gave me earlier.”</i>", parse);
+				Text.Add("<i>“...Somehow, that hurts a lot more than the tail slap you gave me earlier.”</i>", parse);
 				if(player.FirstCock()) {
 					Text.NL();
 					Text.Add("Well, if he didn’t like the tail slap, you could always give him a cock slap instead, you immediately retort.", parse);
@@ -1752,11 +1753,11 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 				}
 			}
 			else {
-				Text.Add("<i>“Ouch! Now you’re just being cruel, [playername].”</i>  He feigns hurt, but you know he’s actually enjoying this. Still… you’d like to get things going, after all you can only humor him for so long. ", parse);
+				Text.Add("<i>“Ouch! Now you’re just being cruel, [playername].”</i> He feigns hurt, but you know he’s actually enjoying this. Still… you’d like to get things going; after all, you can only humor him for so long. ", parse);
 			}
 			Text.NL();
 			parse["ass"] = cale.Slut() >= 30 ? Text.Parse(" and up your ass crack, making sure to tease your [anusDesc]", parse) : "";
-			Text.Add("<i>“Okay then, I suppose there are better things I could do with my mouth than keep talking.”</i> He leans over to give a long lick, over your pussy[ass].", parse);
+			Text.Add("<i>“Okay then, I suppose there are better things I could do with my mouth than keep talking.”</i> He leans over to give a long lick over your pussy[ass].", parse);
 			Text.NL();
 			parse["sf"] = player.body.SoftFeet() ? ", your toes curling at the sensation" : "";
 			Text.Add("You groan deep and loud[sf], a shiver of pleasure racing up your spine. ", parse);
@@ -1769,7 +1770,7 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 				Text.Add("Cale has no reservations about sticking his nose up your ass and licking you to stretch and prepare you for his cock. He rims you with gusto, enjoying each squirm or moan of pleasure he manages to draw from you.", parse);
 			else
 				Text.Add("Cale sets about fingering you, ensuring you’re wet and horny again.", parse);
-			Text.Add(" Once he’s done with that, he aligns his cock with your pussy once more and thrusts in, grinding and stirring up your insides to ensure your juices cling to his cock.", parse);
+			Text.Add(" Once he’s done with that, he aligns his cock with your pussy once more and thrusts in, grinding and stirring up your insides to ensure your juices cling to his dick.", parse);
 			Text.NL();
 			Text.Add("<i>“This should be enough.”</i>  Pulling out, he aligns his cock with your [anusDesc] and grins. <i>“Ready?”</i>", parse);
 			Text.NL();
@@ -1783,7 +1784,7 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 		}, 1.0, function() { return true; });
 		
 		scenes.AddEnc(function() {
-			Text.Add("Without so much as a warning, Cale pulls out of your used vagina and nests his knotty wolf-pecker between the cheeks of your [buttDesc]. He presses the buttcheeks together as he fucks your ass-cleavage, rubbing his length against your rosebud.", parse);
+			Text.Add("Without so much as a warning, Cale pulls out of your used vagina and nests his knotty wolf-pecker between the cheeks of your [buttDesc]. He presses them together as he fucks your ass cleavage, rubbing his length against your rosebud.", parse);
 			Text.NL();
 			
 			Scenes.Cale.SexCaleShowerEntrypoint(outside);
@@ -1797,25 +1798,25 @@ Scenes.Cale.SexCatchVagEntrypoint = function(outside, fromAnal, customIntro) {
 			Text.NL();
 			Text.Add("You lift your head to look Cale in the eye quizzically, letting out a wordless noise of acknowledgement.", parse);
 			Text.NL();
-			Text.Add("<i>“Since you’re properly equipped,”</i> he flicks your [cockTip] with a finger, gathering some spunk on his finger. <i>“And you’ve already had your fun, how about throwing me a bone?”</i> he grins, lapping your cum off his finger.", parse);
+			Text.Add("<i>“Since you’re properly equipped,”</i> he flicks your [cockTip] with a finger, gathering some spunk on his digit, <i>“and you’ve already had your fun, how about throwing me a bone?”</i> he grins, lapping your cum off his finger.", parse);
 			Text.NL();
 			Text.Add("With a weak grin and a faint chuckle, you point out that the spirit may be willing, but the flesh is weak; indicating your spent [cockDesc], you point out you’re not exactly properly set up to give him his bone.", parse);
 			Text.NL();
-			Text.Add("<i>“No worry, [playername]. Doncha know that wolves always lick their bones before the grind?”</i> he suggests with a smirk, hands gripping your hips as he slowly moves you off of his shaft and closer to his maw. Realising what he has in mind, smirking back, you wriggle a little to help him bring your dick into reach of his mouth.", parse);
+			Text.Add("<i>“No worry, [playername]. Don'cha know that wolves always lick their bones before the grind?”</i> he suggests with a smirk, hands gripping your hips as he slowly moves you off of his shaft and closer to his maw. Realizing what he has in mind, smirking back, you wriggle a little to help him bring your dick into reach of his mouth.", parse);
 			Text.NL();
-			Text.Add("Cale wastes no time and engulfs your cock, quickly lathering it with saliva before pulling out and nosing your [cockTip] while his tongue laps at the underside. Tingles race up your spine, your lips pouting in a soft moan as your already-sensitive flesh responds to his tender licks and suckles. In your state, he has you at half-mast within moments, your dick throbbing in time with your heartbeat as it rests against his tongue.", parse);
+			Text.Add("Cale wastes no time and engulfs your cock, quickly lathering it with saliva before pulling out and nosing your [cockTip] while his tongue laps at the underside. Tingles race up your spine, your lips pouting in a soft moan as your already sensitive flesh responds to his tender licks and suckles. In your state, he has you at half-mast within moments, your dick throbbing in time with your heartbeat as it rests against his flexible organ.", parse);
 			Text.NL();
 			if(player.HasBalls()) {
 				Text.Add("He moves under your [multiCockDesc] to lap at your [ballsDesc], sucking on them until they’re nice and plump. Then he moves back to your [cockDesc], returning to his mission.", parse);
 				Text.NL();
 			}
 			parse["sh"] = player.Genitalia().Sheath() ? "your sheath" : "the base of your cock";
-			Text.Add("Cale nuzzles your [cockDesc] giving it an amorous nuzzle, kissing [sh] in the process. Under such treatment, it doesn’t take long for your erection to become as hard as it can get, throbbing and ready for some wolfie ass. <i>“Now ain’t that a sight for sore eyes?”</i> Cale chuckles.", parse);
+			Text.Add("Cale nuzzles your [cockDesc] amorously, kissing [sh] in the process. Under such treatment, it doesn’t take long for your erection to become as hard as it can get, throbbing and ready for some wolfie ass. <i>“Now ain’t that a sight for sore eyes?”</i> Cale chuckles.", parse);
 			Text.NL();
 			Text.Add("You simply grin back, happy to let Cale make his bad jokes when you know what’s coming to you. Besides, you have to agree with him a little anyway.", parse);
 			Text.NL();
 			parse["legs"] = player.LowerBodyType() != LowerBodyType.Single ? "legs are spread and your " : "";
-			Text.Add("<i>“A’ight, let’s get down to business.”</i> He maneuvers you off him and seats you on the [log], ensuring your [legs][cockDesc] is in plain sight. He saunters up to you and aligns you with his needy boypussy. He grins at you expectantly, daring you to take the next step. Certainly not one to back away from this challenge, you grab his hips for leverage and roughly pull him down, plunging your cock into the wolf’s greedy ass in a single swift, powerful thrust.", parse);
+			Text.Add("<i>“A’ight, let’s get down to business.”</i> He maneuvers you off him and seats you on the [log], ensuring your [legs][cockDesc] is in plain sight. He saunters up to you and aligns you with his needy boypussy. He grins at you expectantly, daring you to take the next step. Certainly not one to back away from this challenge, you grab his hips for leverage and roughly pull him down, plunging your cock into the wolf’s greedy ass in a single, swift, powerful thrust.", parse);
 			Text.NL();
 			
 			Scenes.Cale.SexCaleButtslutEntrypoint(cocksInAss, outside);
@@ -1838,28 +1839,28 @@ Scenes.Cale.SexCaleShowerEntrypoint = function(outside) {
 	if(player.SubDom() > 0)
 		Text.Add("Hey! You’re not done yet! What the hell is he doing?", parse);
 	else
-		Text.Add("You whimper in protest, asking what’s going on; why did he take his sweet fat dick out of your needy hole?", parse);
+		Text.Add("You whimper in protest, asking what’s going on; why did he take his sweet, fat dick out of your needy hole?", parse);
 	Text.NL();
-	Text.Add("<i>“Just feel like showering you with my appreciation, [playername]. Plus, you’ve got a really nice butt,”</i> he slaps your butt. <i>“Can ya blame me for wanting to take it for a spin?”</i>", parse);
+	Text.Add("<i>“Just feel like showering you with my appreciation, [playername]. Plus you’ve got a really nice butt,”</i> he slaps your ass. <i>“Can ya blame me for wanting to take it for a spin?”</i>", parse);
 	Text.NL();
 	parse["tail"] = player.HasTail() ? Text.Parse("[tailDesc], ", parse) : "";
 	parse["wing"] = player.HasWings() ? Text.Parse("[wingsDesc], ", parse) : "";
-	Text.Add("Before you can answer that, with a shudder, the wolf cums right then and there. Jets of hot wolf-jism raining down upon your back, splattering your [tail][wing][hairDesc], and your butt. The wolf pumps in-between your buttcheeks a few times more and showers you with a fresh batch. The process continues until he’s spent and you’re absolutely plastered in white wolf cum.", parse);
+	Text.Add("Before you can answer that, the wolf-morph shudders, and cums right then and there. Jets of hot lupine jism raining down upon your back, splattering your [tail][wing][hairDesc], and your butt. Cale pumps in-between your butt cheeks a few times more and showers you with a fresh batch. The process continues until he’s spent and you’re absolutely plastered in white wolf sperm.", parse);
 	Text.NL();
-	Text.Add("<i>“Hehe, that’s a nice look for you,”</i> Cale comments leaning back against the [log] to rest. <i>“You’re now officially marked as my territory.”</i>", parse);
+	Text.Add("<i>“Hehe, that’s a nice look for you,”</i> Cale comments, leaning back against the [log] to rest. <i>“You’re now officially marked as my territory.”</i>", parse);
 	Text.NL();
 	if(player.SubDom() >= 35)
 		Text.Add("You bite back an indignant growl; give the cocky bastard an inch and he takes a mile. No point complaining over spilt cum, though. You’ll just have to show him who belongs to who next time...", parse);
 	else if(player.SubDom() >= -25)
 		Text.Add("You roll your eyes sarcastically. You’d be lying if you said it completely bothered you to get marked this way, but still, you can’t shake the feeling Cale might be starting to get a little big for his proverbial boots...", parse);
 	else
-		Text.Add("You smile happily, shifting slightly to better let the semen on your back flow down your sides and properly coat your skin. You feel quite content to let a stud like Cale mark you as his own; this is what you were meant for, after all.", parse);
+		Text.Add("You smile happily, shifting slightly to better let the semen on your back flow down your sides and properly coat your [skin]. You feel quite content to let a stud like Cale mark you as his own; this is what you were meant for, after all.", parse);
 	Text.NL();
 	Text.Add("<i>“That sure hit the spot,”</i> Cale chuckles, leaning onto the [log] for a quick rest. ", parse);
 	if(cale.Slut() >= 60)
 		Text.Add("<i>“Just remember to return the favor sometime. My ass is aching for a decent fuck, and I could use a bath of my own.”</i> He gives you a gentle slap on your [buttDesc].", parse);
 	else if(cale.Slut() >= 30)
-		Text.Add("<i>“How’d you enjoy your bath? Feels good doesn’t it? I heard it was good for your skin,”</i> Cale teases, chuckling.", parse);
+		Text.Add("<i>“How’d you enjoy your bath? Feels good, doesn’t it? I heard it was good for your skin,”</i> Cale teases, chuckling.", parse);
 	else
 		Text.Add("<i>“You’re my territory now, so I expect to see you around more often. Don’t be a stranger now,”</i> he teases.", parse);
 	Text.NL();
@@ -1884,11 +1885,11 @@ Scenes.Cale.SexCaleCleanCockEntrypoint = function(cock, outside) {
 	Text.NL();
 	Text.Add("No, there most certainly isn’t, you agree, grinning as you lean back to better let him have access to the mess he made.", parse);
 	Text.NL();
-	Text.Add("Cale immediately sets to work, starting off by cleaning your belly. He licks along your navel, playfully teasing you by inserting his tongue into your belly-button. Then he moves upward, licking your [breastsDesc] of their fine layer of wolf-cum.", parse);
+	Text.Add("Cale immediately sets to work, starting off by cleaning your belly. He laps along your navel, playfully teasing you by inserting his tongue into your belly button. Then he moves upward, licking your [breastsDesc] of their fine layer of wolf-cum.", parse);
 	if(player.Lactation())
-		Text.Add(" Course, being the cocky bastard he is, he just can’t resist getting a taste of your nutritious milk along the way. <i>“What? You keep them on display,”</i> he grins.", parse);
+		Text.Add(" 'Course, being the cocky bastard he is, he just can’t resist getting a taste of your nutritious milk along the way. <i>“What? You keep them on display,”</i> he grins.", parse);
 	Text.NL();
-	Text.Add("As soon as he’s done he moves to lick your [cockDesc]. <i>“Some tasty meat for the big bad wolf,”</i> he quips.", parse);
+	Text.Add("As soon as he’s done, he moves to lick your [cockDesc]. <i>“Some tasty meat for the big, bad wolf,”</i> he quips.", parse);
 	Text.NL();
 	Text.Add("You roll your eyes at the cheesy pun, noting to yourself that he certainly wasn’t so bad earlier.", parse);
 	Text.NL();
@@ -1905,7 +1906,7 @@ Scenes.Cale.SexCaleCleanCockEntrypoint = function(cock, outside) {
 	Text.NL();
 	Text.Add("Cale chuckles before replying, <i>“Woof, woof. Where’s my treat?”</i>", parse);
 	Text.NL();
-	Text.Add("Grinning, you point out he just had one. But, maybe you’ll give him another one later.", parse);
+	Text.Add("Grinning, you point out he just had one. But maybe you’ll give him another one later.", parse);
 	Text.NL();
 	Text.Add("He whines playfully, but acquiesces. <i>“Alright, I’ll hold you to that. Don’t be a stranger,”</i> he replies, gathering his own clothes.", parse);
 }
@@ -1930,7 +1931,7 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 	
 	Text.Add("<i>“Hehe, I knew you’d come around. Now, why don’t you relax and let me milk your cock[s] of all its tasty spunk? Not that you have to restrain yourself, I like it rough,”</i> he grins.", parse);
 	Text.NL();
-	Text.Add("Sounds good to you, and your hands slide down Cale’s back so you can squeeze his asscheeks appreciatively, one hand moving to stroke the base of his tail.", parse);
+	Text.Add("Sounds good to you, and your [hand]s slide down Cale’s back so you can squeeze his ass cheeks appreciatively, one hand moving to stroke the base of his tail.", parse);
 	Text.NL();
 	Text.Add("Cale’s legs bulge with exertion as he flexes them in order to rise, letting his quivering sphincter deform around the contour of your [cockDesc]. As soon as only your head remains embedded in his slutty ass Cale stops, there is a brief delay as he lets gravity take over to impale himself back on your flesh pole with a wet squelch. His anal juices cover your shaft with his hot excitement, his trained butt contracts powerfully, giving the impression he’s sucking you in. Cale only stops his descent when he reaches ", parse);
 	if(knotted)
@@ -1938,11 +1939,11 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 	else
 		Text.Add("the base of your cock, having nothing more to take inside himself.", parse);
 	Text.NL();
-	Text.Add("As he stops with a resounding, wet slap, you watch his own shaft bobbing to plop wetly against your belly. Some of his wolfy pre leaving an imprint of his tip on your [skinDesc].", parse);
+	Text.Add("As he stops with a resounding wet slap, you watch his own shaft bobbing to plop wetly against your belly. Some of his wolfy pre leaves an imprint of his tip on your [skinDesc].", parse);
 	Text.NL();
 	Text.Add("You’d have to be a fool to deny Cale’s considerable charms when he decides he wants to be the good cockhungry slut you trained him to be. As great as it feels to have him wrapped around your meat, you can’t simply sit back and let him do it all himself. If he wants to be a proper bitch-boy and take it rough, who are you to deny him?", parse);
 	Text.NL();
-	Text.Add("Sitting up, you wrap your arms around his neck to hold him in place for a wet, rough kiss, bluntly thrusting your [tongueDesc] through his lips to dance and tangle with his own broad, flat tongue. Noisily, you slurp and moan into each other’s mouths, before he breaks the kiss with a gasp.", parse);
+	Text.Add("Sitting up, you wrap your arms around his neck to hold him in place for a wet, rough kiss, bluntly thrusting your [tongueDesc] through his lips to dance and tangle with his own broad, flat tongue. Noisily, you slurp and moan into each other’s mouths before he breaks the lip-lock with a gasp.", parse);
 	Text.NL();
 	Text.Add("Playfully, your head moves to the crook of his neck and you give him a gentle bite, the wolf shuddering in your arms at the gesture. He starts to lift himself back up off of your cock, and you use the motion to help you plant a trail of soft kisses down his neck and over his broad chest until you are level with the exposed pink nub of his nipple. Your tongue playfully flicks out, trailing circles around its expanse before you carefully close your teeth on it in a pleasure-inducing nip that makes him quake.", parse);
 	Text.NL();
@@ -1951,13 +1952,13 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 		Text.Add("until your knot nearly pops in.", parse);
 	else
 		Text.Add("as deep as you can.", parse);
-	Text.Add(" He moans like a whore, and your hands move to his thighs, lifting at him, coaxing him to rise again until you shove him back down again as hard and fast as before. Cale practically sings in his pleasure as you hammer him up and down upon your dick, rutting the lupine buttslut until you can feel the tension boiling up inside of you. You’re going to blow any moment now, you can feel your [cockDesc] throbbing madly with the need to cum, your breath coming quicker and harder as it grows and builds inside of you...", parse);
+	Text.Add(" He moans like a whore, and your hands move to his thighs, lifting at him, coaxing him to rise again until you shove him back down again as hard and fast as before. Cale practically sings in his pleasure as you hammer him up and down upon your dick, rutting the lupine buttslut until you can feel the tension boiling up inside of you. You’re going to blow any moment now; you can feel your [cockDesc] throbbing madly with the need to cum, your breathing coming quicker and harder as it grows and builds within...", parse);
 	Text.NL();
 	Text.Add("<i>“Yeah! Give it to me, give it to me good, [playername]! Mate me like a bitch in heat!”</i> he shamelessly begs.", parse);
 	Text.NL();
 	Text.Add("Like you need the encouragement, pounding the wolf’s butt for all you can, increasingly consumed by your need for release.", parse);
 	if(knotted)
-		Text.Add(" You dimly feel your knot grinding against his tight ring and realise you need to decide what to do with it before you blow your load.", parse);
+		Text.Add(" You dimly feel your knot grinding against his tight ring and realize you need to decide what to do with it before you blow your load.", parse);
 	Text.Flush();
 	
 	var slut = outside ? 4 : 3;
@@ -1977,7 +1978,7 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 				if(cum > 6) {
 					Text.Add("Like a perverse fountain, your cock explodes, sending a veritable tsunami of semen coursing through Cale’s bowels and into his stomach. With your knot wedged inside of him like it is, what little leaks out is literally a few drips in comparison. His belly bloats outward, like a pregnancy on fast forward, the wolf moaning and shuddering as his skin stretches around his titanic liquid suppository.", parse);
 					Text.NL();
-					Text.Add("By the time you finally, blessedly, finish, Cale looks ready to drop a whole litter of full-grown pups of his own, rivulets of semen seeping around the ring and running down your thighs, but unnoticeable by comparison.", parse);
+					Text.Add("By the time you finally - blessedly - finish, Cale looks ready to drop a whole litter of full-grown pups of his own, rivulets of semen seeping around the ring and running down your [thighs], but unnoticeable by comparison.", parse);
 					Text.NL();
 					Text.Add("<i>“Yesh, letsh have lots of puppiesh, honey,”</i> he says, drunk with pleasure. Then he promptly passes out. You chuckle at his reaction as you get yourself comfortable to wait for your knot to deflate.", parse);
 				}
@@ -1990,12 +1991,12 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 					Text.NL();
 					Text.Add("<i>“Y’can come to me whenever you feel like yer gettin case of blue balls and I’ll be happy to milk ‘em for ya. Now if ye’ll excuse me, I’m gonna take a nap.”</i> He nuzzles you and just like that, he’s out like a light.", parse);
 					Text.NL();
-					Text.Add("You chuckle and playfully rub his ears like the overgrown puppy he resembles before settling back and making yourself comfortable, as you wait for your knot to shrink down again.", parse);
+					Text.Add("You chuckle and playfully rub his ears like the overgrown puppy he resembles before settling back and making yourself comfortable as you wait for your knot to shrink down again.", parse);
 				}
 				else {
 					Text.Add("Cale’s belly almost visibly bulges from the size of your deposit inside of him, every last warm drop locked away inside of him by your knot.", parse);
 					Text.NL();
-					Text.Add("<i>“Yeah… Fuck I was really aching for a good shag. Thanks for the treat, [playername].”</i>", parse);
+					Text.Add("<i>“Yeah… Fuck, I was really aching for a good shag. Thanks for the treat, [playername].”</i>", parse);
 					Text.NL();
 					Text.Add("It was your pleasure, you assure him.", parse);
 					Text.NL();
@@ -2004,15 +2005,15 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 					Text.Add("Of course you don’t mind, and you quickly tell him so.", parse);
 					Text.NL();
 					parse["balls"] = player.HasBalls() ? " balls deep" : "";
-					Text.Add("<i>“Thanks.”</i> He nuzzles you and closes his eyes, his breathing stabilizing as he falls asleep. With your cock still buried[balls] inside him.", parse);
+					Text.Add("<i>“Thanks.”</i> He nuzzles you and closes his eyes, his breathing stabilizing as he falls asleep with your cock still buried[balls] inside him.", parse);
 					Text.NL();
-					Text.Add("You can’t help but smile; that’s Cale for you, alright. Shifting him to be a little more comfortable against you, you then move yourself around to make yourself a little more comfortable as well. Going to take a while for your knot to deflate, after all.", parse);
+					Text.Add("You can’t help but smile; that’s Cale for you, alright. Shifting him to be a little more comfortable against you, you try to shuffle a little to make yourself more comfortable as well. It's going to take a while for your knot to deflate, after all.", parse);
 				}
 				Text.Flush();
 				
 				Gui.NextPrompt(function() {
 					Text.Clear();
-					Text.Add("It takes the better part of an hour till your knot’s shrunk down enough to let you unplug Cale’s ass. By then the wolf’s already woken up.", parse);
+					Text.Add("It takes the better part of an hour till your knot’s shrunk down enough to let you unplug Cale’s ass. By then, the wolf’s already woken up.", parse);
 					Text.NL();
 					
 					Scenes.Cale.SexCaleCleanCockEntrypoint(p1cock, outside);
@@ -2034,20 +2035,20 @@ Scenes.Cale.SexCaleButtslutEntrypoint = function(cocks, outside) {
 	options.push({ nameStr : "Nah",
 		func : function() {
 			Text.Clear();
-			Text.Add("You thrust into Cale’s ass as deeply as you can, the two of you crying out in mutual pleasure as your limits are breached and the both of you climax in unison. Cale’s seed sprays across your stomach and [breastsDesc], trickling strands of off-white running down your [skinDesc], even as your own seed floods inside of his ass.", parse);
+			Text.Add("You thrust into Cale’s colon as deeply as you can, the two of you crying out in mutual pleasure as your limits are breached and the both of you climax in unison. Cale’s seed sprays across your stomach and [breastsDesc], trickling strands of off-white running down your [skinDesc], even as your cum floods inside of his ass.", parse);
 			Text.NL();
 			
 			var cum = player.OrgasmCum();
 			
 			if(cum > 6) {
-				Text.Add("Veritable rivers of semen spurt out around the imperfect seal of your cock, but such is the sheer cascade of your spooge flooding inside of Cale that his stomach still begins to grow and grow, ballooning out into a pregnant looking swell. Even after your member finally goes slack, allowing semen to pour freely between his thighs, he can’t drain fast enough to shrink his new gut.", parse);
+				Text.Add("Veritable rivers of semen spurt out around the imperfect seal of your cock, but such is the sheer cascade of your spooge flooding inside of Cale that his stomach still begins to grow and grow, ballooning out into a pregnant-looking swell. Even after your member finally goes slack, allowing sperm to pour freely between his thighs, he can’t drain fast enough to shrink his new gut.", parse);
 				Text.NL();
 				Text.Add("<i>“Hehe, someone had a serious case of blue balls… or was it just that good?”</i> he teases.", parse);
 				Text.NL();
 				Text.Add("Maybe a little from column A and a little from column B, you quip right back, tapping him playfully on his newly expanded stomach.", parse);
 			}
 			else if(cum > 3) {
-				Text.Add("Thick ropes of semen pour into Cale’s stomach, swelling his gut out into a blatant pot belly. Though some of your seed is drawn back down by gravity, oozing sluggishly around the ring of his ass, most of it floods inside of him, leaving him with a nicely pregnant-looking bulge by the time you finish.", parse);
+				Text.Add("Thick ropes of semen pour into Cale’s stomach, swelling his gut out into a blatant potbelly. Though some of your seed is drawn back down by gravity, oozing sluggishly around the ring of his ass, most of it floods inside of him, leaving him with a nicely pregnant-looking bulge by the time you finish.", parse);
 				Text.NL();
 				Text.Add("<i>“Ah, nice and sloppy. Just the way I like it,”</i> he grins, gripping your cock with his sphincter.", parse);
 				Text.NL();
@@ -2096,13 +2097,13 @@ Scenes.Cale.SexCatchAnal = function(outside) {
 	Text.NL();
 	Text.Add("You start out by approaching him and deftly sticking your hand inside his pants to fondle his rapidly filling sheath and balls. <i>“You got me!”</i> he says jokingly. You simply roll your eyes and begin to undo his garments. He just looks at you with a smile, fumbling with his top. In no time at all, the sound of rustling clothes is pointed by the sound of said clothes hitting the ground, and you’re left to look at the athletic wolf in all his naked glory.", parse);
 	Text.NL();
-	Text.Add("Orange eyes glitter with amusement as he watches you, lips curved in a wolfish grin. His lupine ears flick atop his head in visible impatience, tail wagging over a toned butt. Though his body is covered in dark fur, it isn't dense enough to stop you from making out that he has a trim build; solid and graceful, with some visible muscle, but not swollen and hulking - a runner, more than a weightlifter. Jutting between his legs, his nine-inches of wolf-cock practically throb before your eyes, eager to be buried inside of you.", parse);
+	Text.Add("Orange eyes glitter with amusement as he watches you, lips curved in a wolfish grin. His lupine ears flick atop his head in visible impatience, tail wagging over a toned butt. Though his body is covered in dark fur, it isn't dense enough to stop you from making out that he has a trim build: solid and graceful, with some visible muscle, but not swollen and hulking - a runner, more than a weightlifter. Jutting between his legs, his nine inches of wolf-cock practically throbs before your eyes, eager to be buried inside of you.", parse);
 	Text.NL();
 	Text.Add("Putting an end to your scrutiny, Cale moves to work on your [lowerArmorDesc] himself. You don’t wait to get started on your top, shrugging out of your clothes in record speed. Cale loops an arm around your lower back and motions to the [log]. His intentions clear, you bend over and await the wolf’s next move.", parse);
 	Text.NL();
-	Text.Add("<i>“Let’s prep you first. I dunno bout you, but I’m not a fan of painful intrusions.”</i> He moves to his discarded top, fumbling about with a pouch to draw a small tube containing what look to be a clear gel.", parse);
+	Text.Add("<i>“Let’s prep you first. I dunno 'bout you, but I’m not a fan of painful intrusions.”</i> He moves to his discarded top, fumbling about with a pouch to draw a small tube containing what look to be a clear gel.", parse);
 	Text.NL();
-	Text.Add("You shiver unconsciously as the cool gel oozes over your flesh, tingling against the skin as he applies it. Once he judges the amount sufficient, an expert finger moves to massage the lube into your [anusDesc], slow and deliberate motions stirring it around and around. Once he judges your ring has been sufficiently coated, he starts to work his way inside your pucker with a fingertip, thrusting in and out with the same tantalizing purposefulness. Slowly, he adds a second finger, pumping them deeper inside of you as he does. Blissfully, he adds a third, painstakingly reaming your ass with all three.", parse);
+	Text.Add("You shiver unconsciously as the cool gel oozes over your flesh, tingling against the skin as he applies it. Once he judges the amount sufficient, an expert digit moves to massage the lube into your [anusDesc], slow and deliberate motions stirring it around and around. Once he judges your ring has been sufficiently coated, he starts to work his way inside your pucker with a fingertip, thrusting in and out with the same tantalizing purposefulness. Slowly, he adds a second finger, pumping them deeper inside of you as he does. Blissfully, he adds a third, painstakingly reaming your ass with all three.", parse);
 	Text.NL();
 	Text.Add("<i>“How ya doing up there? Feel ready yet?”</i> he asks continuing to pump his three fingers inside you.", parse);
 	Text.NL();
@@ -2126,10 +2127,10 @@ Scenes.Cale.SexCatchAnal = function(outside) {
 	else if(cale.flags["sneakAtk"] == 5) {
 		Text.Add("Ugh, not again. You roll your eyes in contempt and cut him off, telling him to drop the stupid ‘sneak attack’ joke, it's really gotten old. Just stick his dick in your ass and let's get down to what you're both here for.", parse);
 		Text.NL();
-		Text.Add("<i>“Aw, you’re no fun,”</i> he protests weakly, but complies. After some minor adjusting he spears himself into you, all nine inches, until he’s balls-deep inside your [anusDesc].", parse);
+		Text.Add("<i>“Aw, you’re no fun,”</i> he protests weakly, but complies. After some minor adjusting, he spears himself into you, all nine inches, until he’s balls deep inside your [anusDesc].", parse);
 	}
 	else {
-		Text.Add("<i>“Here I come~”</i> He thrusts into you, burying all of his nine-inch wolfhood balls-deep into your rectum.", parse);
+		Text.Add("<i>“Here I come~”</i> He thrusts into you, burying all of his nine inch wolfhood balls deep into your rectum.", parse);
 	}
 	cale.flags["sneakAtk"]++;
 	
@@ -2172,18 +2173,18 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 
 	parse["wings"] = player.HasWings() ? Text.Parse(" being careful with your [wingsDesc],", parse) : "";
 	parse["p"] = player.FirstCock() ? ", including your prostate" : "";
-	Text.Add("Cale bends over your back,[wings] as he hugs your from behind. His position is reminiscing of a wolf mounting his bitch, a detail that probably passes him by as he’s too busy thrusting away into your ass. The position does allow him to go a bit deeper than before and though erratic, his thrusts manage to hit all the right spots inside you[p].", parse);
+	Text.Add("Cale bends over your back,[wings] as he hugs your from behind. His position is reminiscent of a wolf mounting his bitch, a detail that probably passes him by as he’s too busy thrusting away into your ass. The position does allow him to go a bit deeper than before and though erratic, his thrusts manage to hit all the right spots inside you[p].", parse);
 	Text.NL();
-	Text.Add("You groan and growl, deep and low in your throat as you feel him gyrating and grinding against your inner walls; he’s rough - but in a good way. Stirred by his efforts, you shift yourself around slightly, allowing you to start meeting his humping with backwards bucks of your own, swallowing each thrusting of his cock with eager ease. Even in your increasingly addled state, you’re aware of the thick, swollen girth of his excited knot as it sometimes forces its way inside of you, stretching you a few delicious extra inches when it does.", parse);
+	Text.Add("You groan and growl, deep and low, in your throat as you feel him gyrating and grinding against your inner walls; he’s rough - but in a good way. Stirred by his efforts, you shift yourself around slightly, allowing you to start meeting his humping with backwards bucks of your own, swallowing each thrusting of his cock with eager ease. Even in your increasingly addled state, you’re aware of the thick, swollen girth of his excited knot as it sometimes forces its way inside of you, stretching you a few delicious extra inches when it does.", parse);
 	Text.NL();
-	Text.Add("<i>“So tight and hot…”</i> you hear Cale comment, his pumping slowly becoming a bit more well paced. Now that you’re actively fucking him back, he doesn’t feel the need to be so… desperate, in his taking of your [anusDesc]. Short strokes become long ones, and with each synced thrust and buck, the resulting impact sends ripples along your [buttDesc]. His knot has inflated enough that he can’t just idly push it inside you anymore, and you can feel its girth whenever Cale grinds into your butt. It feels like he might push in at a moment’s notice, but he always withdraws in the last second.", parse);
+	Text.Add("<i>“So tight and hot…”</i> you hear Cale comment, his pumping slowly becoming a bit more well paced. Now that you’re actively fucking him back, he doesn’t feel the need to be so… desperate in his taking of your [anusDesc]. Short strokes become long ones, and with each synced thrust and buck, the resulting impact sends ripples along your [buttDesc]. His knot has inflated enough that he can’t just idly push it inside you anymore, and you can feel its girth whenever Cale grinds into your butt. It feels like he might push in at a moment’s notice, but he always withdraws in the last second.", parse);
 	Text.NL();
 	
 	var scenes = new EncounterTable();
 	scenes.AddEnc(function() {
-		Text.Add("<i>“Hey, [playername]. You ready for this?”</i> he asks, grinding against your [anusDesc] so you can feel his inflated knot. <i>“So what about it? Can you take all that Cale has to offer,”</i> he pants, waiting for your reply.", parse);
+		Text.Add("<i>“Hey, [playername]. You ready for this?”</i> he asks, grinding against your [anusDesc] so you can feel his inflated knot. <i>“So how about it? Can you take all that Cale has to offer,”</i> he pants, waiting for your reply.", parse);
 		Text.NL();
-		Text.Add("You realise he’s giving you the final say; you better make a decision quickly...", parse);
+		Text.Add("You realize he’s giving you the final say; you better make a decision quickly...", parse);
 		Text.Flush();
 		
 		//[Yes][No]
@@ -2193,7 +2194,7 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 				Text.Clear();
 				Text.Add("Rather than waste time with words, you let your body do the talking, grinding back against Cale’s hips as best you can from your present position. You will your clenching asshole to open further, stretching yourself out with each centimeter you force yourself back over Cale’s bulging knot. Gritting your teeth from the effort, you strain with all your might, crying out in triumph as you finally force him inside of you to the hilt, anchoring him within your ass.", parse);
 				Text.NL();
-				Text.Add("<i>“Knew you had it in you.,”</i> he chuckles, switching from his long thrusts to smaller one as his knot stirs your insides. It doesn’t take long before he tightens his grip on your flanks and howls. The distinct warmth of Cale’s hot seed flooding your insides as the wolf orgasms.", parse);
+				Text.Add("<i>“Knew you had it in you,”</i> he chuckles, switching from his long thrusts to smaller one as his knot stirs your insides. It doesn’t take long before he tightens his grip on your flanks and howls. The distinct warmth of Cale’s hot seed floods your insides as the wolf orgasms.", parse);
 				Text.NL();
 				
 				Scenes.Cale.Impregnate(player, PregnancyHandler.Slot.Butt, 4);
@@ -2205,28 +2206,28 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 					parse["cum"] = cum > 6 ? "flooding" :
 					               cum > 3 ? "pooling" :
 					               "spattering";
-					Text.Add(" Your seed splashes onto the earth below you, [cum] where it lands and filling the air with its distinctive musk.", parse);
+					Text.Add(" Your sperm splashes onto the earth below you, [cum] where it lands and filling the air with its distinctive musk.", parse);
 				}
 				if(player.FirstVag()) {
 					Text.Add(" Your womanhood drools its nectar down your [legsDesc], soaking into the thirsty ground below.", parse);
 				}
 				Text.NL();
-				Text.Add("Cale’s seed continues its assault, plowing deep inside you to settle in your belly. With nowhere to go, all of it winds up inside you. You can feel his liquid burden stretching your belly, slowly inflating you as his powerful jets are reduced to a faint trickle. <i>“F-Fuck. That’s one sweet ass you got there, [playername]. My balls are even sore now,”</i> he chuckles.", parse);
+				Text.Add("Cale’s seed continues its assault, plowing deep inside you to settle in your belly. With nowhere to go, all of it winds up inside you. You can feel his liquid burden stretching your stomach, slowly inflating you as his powerful jets are reduced to a faint trickle. <i>“F-fuck. That’s one sweet ass you got there, [playername]. My balls are even sore now,”</i> he chuckles.", parse);
 				Text.NL();
 				Text.Add("Like he didn’t enjoy every moment of it, you smirk to yourself. You wriggle a little to better adjust to your new weight, confirming that you are well and truly stuck to his crotch.", parse);
 				Text.NL();
-				Text.Add("<i>“It’ll be a while before I can let ya go, so let’s get ya in a more comfortable position.”</i> The wolf grabs you around your waist, just below the paunch his seed’s given you and hauls you up into a sitting position on his lap. The motions sends the liquids inside you sloshing, and you react by tightening your sphincter around his knot. Cale spurts a fresh rope of wolf-seed in reply.", parse);
+				Text.Add("<i>“It’ll be a while before I can let ya go, so let’s get ya in a more comfortable position.”</i> The wolf grabs you around your waist, just below the paunch his seed’s given you and hauls you up into a sitting position on his lap. The motions send the liquid inside you sloshing, and you react by tightening your sphincter around his knot. Cale spurts a fresh rope of wolf-seed in reply.", parse);
 				Text.NL();
 				Text.Add("You grunt a little at the treatment, your [legsDesc] wobbling a little, but manage to shift in Cale’s lap to find a position that you feel comfortable in. That done, you settle back against his furry chest and allow yourself to relax.", parse);
 				Text.Flush();
 				
 				Gui.NextPrompt(function() {
 					Text.Clear();
-					Text.Add("It takes the better part of an hour for his knot to deflate, a time that he spent being nothing but gentlemanly. Although he’s shrunk enough that he could pull out, he’s too engrossed in his current task to actually do so. The wolf is busy grooming you with licks around your collar bone, drinking in the sweat resulting of your taking.", parse);
+					Text.Add("It takes the better part of an hour for his knot to deflate, a time that he spent being nothing but gentlemanly. Although he’s shrunk enough that he could pull out, he’s too engrossed in his current task to actually do so. The wolf is busy grooming you with licks around your collarbone, drinking in the sweat resulting of your taking.", parse);
 					Text.NL();
 					Text.Add("Sighing softly, you tell him that as enjoyable as this is, you can’t stay here forever; there’s things you need to do. You allow him a last cuddle and then, once he’s let you go, you pull yourself free of his lap. Naturally, without his cock plugging your ass anymore, a cascade of semen falls down your [legsDesc] and splatters messily over his own crotch before you manage to close your asshole again, but he doesn’t seem to care in the slightest.", parse);
 					Text.NL();
-					Text.Add("<i>“Y’know where to find me. Anytime you need,”</i> he says with a cocky smile, waving you away as he leans back against the [log], enjoying his afterglow too much to even bother putting his clothes back for now.", parse);
+					Text.Add("<i>“Y’know where to find me - anytime you need,”</i> he says with a cocky smile, waving you away as he leans back against the [log], enjoying his afterglow too much to even bother putting his clothes back for now.", parse);
 					Text.NL();
 					Text.Add("You finish cleaning yourself off as best you can, then grab your [armorDesc] and get dressed again before leaving the happy wolf-morph to his relaxation.", parse);
 					Text.Flush();
@@ -2242,7 +2243,7 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 		options.push({ nameStr : "No",
 			func : function() {
 				Text.Clear();
-				Text.Add("<i>“Aw, too bad. But it’s alright, I still got a lot. To. Give. You,”</i> he says pointing each word with a rough thrust.", parse);
+				Text.Add("<i>“Aw, too bad. But it’s alright, I still got a lot. To. Give. You,”</i> he says, punctuating each word with a rough thrust.", parse);
 				Text.NL();
 				Text.Add("You groan wordlessly, clenching down against his shaft. He’s picked up his pace to the speed he was using when you began, reaming you hard and fast as he can. You quake and heave, bucking beneath him; you can’t take much more of this...", parse);
 				Text.NL();
@@ -2260,11 +2261,11 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 				
 				var cum = player.OrgasmCum();
 				
-				Text.Add("Without his knot to hold the seed in, most of it wind up leaking around the seal of your ass, splattering your butt with white. Only when the jets are reduced to a trickle does Cale pull away, sputtering a couple weak ropes onto your [buttDesc]. <i>“Ah, that hit the spot. Too bad y’ wouldn’t let me tie,”</i> he says, panting as he sits down beside you and leans on the [log].", parse);
+				Text.Add("Without his knot to hold the seed in, most of it winds up leaking around the seal of your ass, splattering your butt with white. Only when the jets are reduced to a trickle does Cale pull away, sputtering a couple weak ropes onto your [buttDesc]. <i>“Ah, that hit the spot. Too bad y’ wouldn’t let me tie,”</i> he says, panting as he sits down beside you and leans on the [log].", parse);
 				Text.NL();
 				Text.Add("You simply pant, regaining your strength. Once you can move again, you gather your gear and thank Cale for the nice time, already absently looking for a place to properly clean yourself up.", parse);
 				Text.NL();
-				Text.Add("<i>“You’re welcome, if you want any more y’know where to find me,”</i> he grins waving you away.", parse);
+				Text.Add("<i>“You’re welcome; if you want any more, y’know where to find me,”</i> he grins, waving you away.", parse);
 				Text.Flush();
 				
 				cale.relation.IncreaseStat(100, 3);
@@ -2279,14 +2280,14 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 	
 	if(fromVag == null) {
 		scenes.AddEnc(function() {
-			Text.Add("You find yourself growling in frustration, so close to the edge you can nearly taste it. As Cale pulls his hips back again, you find him suddenly withdrawing his cock out entirely, leaving your [anusDesc] squeezing in vain on empty air and you asking what’s wrong - doesn’t he want to finish this?", parse);
+			Text.Add("You find yourself growling in frustration, so close to the edge that you can nearly taste it. As Cale pulls his hips back again, you find him suddenly withdrawing his cock out entirely, leaving your [anusDesc] squeezing in vain on empty air and you asking what’s wrong - doesn’t he want to finish this?", parse);
 			Text.NL();
-			Text.Add("<i>“Don’t worry, I wanna get off as much as ya do, just thought I’d mix things up a bit.”</i>", parse);
+			Text.Add("<i>“Don’t worry, I wanna get off as much as ya do - just thought I’d mix things up a bit.”</i>", parse);
 			Text.NL();
 			Text.Add("Twisting around to look back over your shoulder at him, you raise an eyebrow and ask what he has in mind.", parse);
 			Text.NL();
 			if(cale.Slut() >= 60 && player.FirstCock())
-				Text.Add("<i>“Normally I’d home in on [thisThese] juicy cock[s] of yours,”</i> he says, giving your [multiCockDesc] an appreciative stroke. <i>“But, this time I think I’ll try this bit.”</i> He runs a finger along the moist slit of your [vagDesc].", parse);
+				Text.Add("<i>“Normally, I’d home in on [thisThese] juicy cock[s] of yours,”</i> he says, giving your [multiCockDesc] an appreciative stroke. <i>“But this time, I think I’ll try this bit.”</i> He runs a finger along the moist slit of your [vagDesc].", parse);
 			else
 				Text.Add("<i>“Well, you got such a pretty pussy down here,”</i> he runs a finger along your moist slit, <i>“that I can’t help but want to give it a shot. So I’mma do just that.”</i> He grins.", parse);
 			Text.NL();
@@ -2296,7 +2297,7 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 			Text.NL();
 			parse["br"] = player.FirstBreastRow().Size() >= 5 ? ", smothering him in your cleavage" : "";
 			parse["c"] = player.FirstCock() ? Text.Parse(", your hard [multiCockDesc] rubbing against his belly", parse) : "";
-			Text.Add("Your hands reach for his shoulders and you push down, firmly and insistently, sending him thumping softly to the ground below. You break the kiss at last, leaving him panting for breath, and close the distance between you by straddling him, arms pulling his face against your [breastsDesc][br][c]. Downwards you slide until you can feel your [vagDesc] in proper alignment with his straining wolfhood, smirking as you look into his eyes. Cale licks his lips, eager to begin.", parse);
+			Text.Add("Your hands reach for his shoulders and you push down, firmly and insistently, sending him thumping softly to the ground below. You break the kiss at last, leaving him panting for breath, and close the distance between you by straddling him, arms pulling his face against your [breastsDesc][br][c]. You slide downwards until you can feel your [vagDesc] in proper alignment with his straining wolfhood, smirking as you look into his eyes. Cale licks his lips, eager to begin.", parse);
 			Text.Flush();
 			
 			Gui.NextPrompt(function() {
@@ -2306,7 +2307,7 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 		}, 1.0, function() { return player.FirstVag(); });
 		
 		scenes.AddEnc(function() {
-			Text.Add("Without so much as a warning, Cale pulls out of your abused ass and nests his knotty wolf-pecker between the cheeks of your [buttDesc]. He presses the buttcheeks together as he fucks your ass-cleavage, rubbing his length against your rosebud.", parse);
+			Text.Add("Without so much as a warning, Cale pulls out of your abused ass and nests his knotty wolf-pecker between the cheeks of your [buttDesc]. He presses them together as he fucks your ass cleavage, rubbing his length against your rosebud.", parse);
 			Text.NL();
 			
 			Scenes.Cale.SexCaleShowerEntrypoint(outside);
@@ -2315,13 +2316,13 @@ Scenes.Cale.SexCatchAnalEntrypoint = function(outside, fromVag) {
 		scenes.AddEnc(function() {
 			Text.Add("<i>“Hey, [playername]?”</i>", parse);
 			Text.NL();
-			Text.Add("You give Cale an idle grunt of acknowledgement back, more concerned with the feeling of his lupine fuckmeat ploughing your asshole.", parse);
+			Text.Add("You give Cale an idle grunt of acknowledgement back, more concerned with the feeling of his lupine fuckmeat plowing your asshole.", parse);
 			Text.NL();
 			Text.Add("<i>“No offense, but I really need this.”</i>", parse);
 			Text.NL();
 			Text.Add("That statement is enough to make you blink in surprise. You open your mouth, intending to ask him what he means, but all that escapes you is a drawn-out blissful moan as he smoothly extracts himself from you. This gives way to a surprised grunt when he suddenly grabs you by the hips and spins you around, leaving you sitting back against the [log] you were previously leaning over. You shake your head, but any attempt to gather your thoughts are cut off when Cale, having moved to squat over you, suddenly drops ass-first into your lap, audibly squelching wetly as[oneof] your [multiCockDesc] plunges meatily into the well-trained tailhole of your lupine buttslut.", parse);
 			Text.NL();
-			Text.Add("<i>“Yes! This is the best. Nothing quite like a hard cock to plug up my need behind.”</i>", parse);
+			Text.Add("<i>“Yes! This is the best. Nothing quite like a hard cock to plug up my needy behind.”</i>", parse);
 			Text.NL();
 			Text.Add("Groaning softly as Cale’s not inconsiderable weight smacks into your belly, you can’t resist commenting that this certainly wasn’t what you expected when you offered to let him fuck your ass instead.", parse);
 			Text.NL();
@@ -2388,9 +2389,9 @@ Scenes.Cale.SexFuckingHimOutsideComments = function(cock, opts) {
 	var breakpoint = false;
 	
 	if(goopFirst) {
-		Text.Add("<i>“Sometimes I amaze myself with my own genius. How’s your ass doing Cale?”</i> Rosalin asks curiously. The wolf doesn’t even react to [hisher] teasing, and even if he noticed he’s too busy moaning like a bitch in heat to reply anyway.", parse);
+		Text.Add("<i>“Sometimes, I amaze myself with my own genius. How’s your ass doing Cale?”</i> Rosalin asks curiously. The wolf doesn’t even react to [hisher] teasing, and even if he noticed he’s too busy moaning like a bitch in heat to reply anyway.", parse);
 		Text.NL();
-		Text.Add("<i>“That’s good,”</i> [heshe] says fetching a notepad nearby and jotting down some notes. <i>“[playername], go a bit deeper, I want to see his reaction.”</i>", parse);
+		Text.Add("<i>“That’s good,”</i> [heshe] says, fetching a notepad nearby and jotting down some notes. <i>“[playername], go a bit deeper, I want to see his reaction.”</i>", parse);
 		Text.NL();
 		Text.Add("You nod at [hisher] request. Not like you weren’t planning on doing so anyway. Drawing back your [cockDesc] until only your [cockTip] remains planted inside the wolf’s quivering rosebud, you thrust inside with all your strength.", parse);
 		Text.NL();
@@ -2461,27 +2462,27 @@ Scenes.Cale.SexFuckingHimOutsideComments = function(cock, opts) {
 				parse["reluctantly"] = cale.Slut() < 30 ? " reluctantly" : "";
 				Text.Add("Cale[reluctantly] opens his maw and lets his broad tongue roll out. You resolve to simply slow down and appreciate the show before you resume giving Cale’s butt the treatment it deserves.", parse);
 				Text.NL();
-				Text.Add("Estevan wastes no time in taking the wolf’s invitation. He jams the first few inches in a single thrust, muffling a surprised yelp from the wolf. You grind against Cale’s butt, watching as Estevan grabs Cale’s scalp and pulls him toward himself. The wolf has no choice but to comply, at the same time his muzzle is impaled onto Estevan’s cock, his butt is drawn away from your [cockDesc], until only the [cockTip] is left inside.", parse);
+				Text.Add("Estevan wastes no time in taking the wolf’s invitation. He jams the first few inches in a single thrust, muffling a surprised yelp from the wolf. You grind against Cale’s butt, watching as Estevan grabs Cale’s scalp and pulls him toward himself. The wolf has no choice but to comply; at the same time his muzzle is impaled onto Estevan’s cock, his ass is drawn away from your [cockDesc] until only the [cockTip] is left inside.", parse);
 				Text.NL();
 				Text.Add("You can’t be having that; your hands lock onto the wolf’s boyish hips and you pull backwards, firmly dragging his ass back down the length of your [cockDesc]. The satyr catches on quickly, grinning as he throws himself into this new game. The poor wolf is pulled back and forth between you, helpless to stop either of you from ravaging his holes.", parse);
 				Text.NL();
 				Text.Add("<i>“Mmm, nice and tight! How is your end, [playername]?”</i> the satyr quips, scratching Cale behind the ear as one would a dog. ", parse);
 				if(cale.Slut() >= 60)
-					Text.Add("Tight and wet, as usual. You’ve marked Cale’s butt as your territory so many times his ass is pretty much shaped to your [cockDesc].", parse);
+					Text.Add("Tight and wet, as usual. You’ve marked Cale’s butt as your territory so many times that his ass is pretty much shaped to your [cockDesc].", parse);
 				else if(cale.Slut() >= 30)
 					Text.Add("Nice and tight as well. Cale’s butt is familiar territory, and you know just how to push his buttons when you want him tighter or looser for the taking.", parse);
 				else
 					Text.Add("Bit too much on the tight side. This here’s an ass that hasn’t seen enough action yet. A fact you plan to rectify as soon as possible.", parse);
 				Text.NL();
-				Text.Add("<i>“Sounds like I’ll have to try it out later. Perhaps if I find him in one of my traps some day... You’d like that, wouldn’t you doggie?”</i> Estevan grins down at his rival. Cale’s expression is a mixture of defiance, tinged with a touch of fear. The satyr is still his usual jovial self, but the look in his eyes suggests he isn’t joking.", parse);
+				Text.Add("<i>“Sounds like I’ll have to try it out later. Perhaps if I find him in one of my traps some day... You’d like that, wouldn’t you, doggie?”</i> Estevan grins down at his rival. Cale’s expression is a mixture of defiance, tinged with a touch of fear. The satyr is still his usual jovial self, but the look in his eyes suggests he isn’t joking.", parse);
 				Text.NL();
 				Text.Add("As long as he remembers that Cale is <i>your</i> bitch and brings him home in one piece, you’ve got no objections.", parse);
 				Text.NL();
-				Text.Add("<i>“And don’t tire him out too much, I need him to run errands for me,”</i> Rosalin adds, reminding Cale that she’s also there.", parse);
+				Text.Add("<i>“And don’t tire him out too much, I need him to run errands for me,”</i> Rosalin adds, reminding Cale that [heshe]’s also there.", parse);
 				Text.NL();
 				Text.Add("<i>“Don’t worry, I’ll keep that in mind,”</i> the satyr replies with a chuckle.", parse);
 				Text.NL();
-				Text.Add("Cale - bullied from every side - finally gives up his pretense to resistance, rocking his hips in rhythm with you and Estevan. His surrender hasn’t escaped the satyr, who doubles his pace, deepthroating the wolf in almost a frenzy. From your perspective, it’s quite clear he’s just about to come, though the slut with his lips wrapped around the satyr’s cock is still blissfully unaware.", parse);
+				Text.Add("Cale - bullied from every side - finally gives up his pretense to resistance, rocking his hips in rhythm with you and Estevan. His surrender hasn’t escaped the satyr, who doubles his pace, deepthroating the wolf in almost a frenzy. From your perspective, it’s quite clear he’s just about to cum, though the slut with his lips wrapped around the satyr’s cock is still blissfully unaware.", parse);
 				Text.NL();
 				Text.Add("The wolf’s eyes bulge wide open as the satyr suddenly reaches his climax, pouring a load worthy of his hefty balls down Cale’s throat. The process goes on for quite a bit longer than the wolf is comfortable with, and you can feel him struggle weakly against his rival. You give him an admonishing slap on the butt, taking the chance to shove your [cockDesc] home to remind him of his place.", parse);
 				Text.NL();
@@ -2490,7 +2491,7 @@ Scenes.Cale.SexFuckingHimOutsideComments = function(cock, opts) {
 				if(first)
 					Text.Add("<i>“Thanks for the ride, [playername]!”</i> Estevan thanks you, still eyeing his rival mockingly. <i>“Who knew, there <b>is</b> something that you’re good at, wolfie!”</i>", parse);
 				else
-					Text.Add("<i>“Thanks for another go at the camp slut, [playername]!”</i> Estevan thanks you, scratching the wolf behind his ears. <i>“I don’t know wolfie, you seemed more into it than last time, are you maybe starting to like me? Well, my cock, that is.”</i>", parse);
+					Text.Add("<i>“Thanks for another go at the camp slut, [playername]!”</i> Estevan thanks you, scratching the wolf behind his ears. <i>“I don’t know, wolfie, you seemed more into it than last time. Are you maybe starting to like me? Well, my cock, that is.”</i>", parse);
 				Text.Add(" With that, he leaves you alone with a Cale stuffed full of spunk. Well, you’ve still got business to take care of with the wolf...", parse);
 				Text.NL();
 				
@@ -2513,7 +2514,7 @@ Scenes.Cale.SexFuckingHimOutsideComments = function(cock, opts) {
 				
 				PrintDefaultOptions();
 			}, enabled : true,
-			tooltip : "Nah, as amusing as that would be, Cale is <i>your</i> price."
+			tooltip : "Nah, as amusing as that would be, Cale is <i>your</i> prize."
 		});
 		Gui.SetButtonsFromList(options, false, null);
 		
@@ -2534,15 +2535,15 @@ Scenes.Cale.SexFuckingHimOutsideComments = function(cock, opts) {
 			Text.Add("<i>“Hiii Cale!”</i> Rosalin waves as [heshe] notices the two of you going at it. [HeShe] wanders over, seemingly oblivious to the wolf’s current situation. The [racedesc] carries a few bottles, and [heshe] looks very preoccupied. <i>“Listen, do you think you could get a few dozen canis roots for me? I need some for an experiment.”</i>", parse);
 			Text.NL();
 			if(rosalin.FirstCock()) {
-				Text.Add("Though [heshe] might act coyly nonchalant, [hisher] body is more than aware of what is going on, as you can see [hisher] [rmultiCockDesc] straining against [hisher] skirt, aching for release. Cale himself must have an even better view of it, from his front-row seat.", parse);
+				Text.Add("Though [heshe] might act coyly nonchalant, [hisher] body is more than aware of what is going on as you can see [hisher] [rmultiCockDesc] straining against [hisher] skirt, aching for release. Cale himself must have an even better view of it from his front-row seat.", parse);
 				Text.NL();
 			}
 			Text.Add("<i>“I- Ah! - now is a b-bad time, Rosie,”</i> the wolf whimpers, wincing as you drive into him with undiminished fervor.", parse);
 			Text.NL();
 			if(player.FirstCock() || rosalin.FirstCock())
-				Text.Add("<i>“You see, I was thinking of making a potion that could give someone a nice big knot, or significantly expand an already existing one. I dunno, would you like that?”</i> Cale just moans, not even sure if she’s teasing him or being serious. Probably both.", parse);
+				Text.Add("<i>“You see, I was thinking of making a potion that could give someone a nice big knot, or significantly expand an already existing one. I dunno, would you like that?”</i> Cale just moans, not even sure if [heshe]’s teasing him or being serious. Probably both.", parse);
 			else
-				Text.Add("<i>“Ah, all right. I had a recipe in mind that could increase the size of your knot a bit, but on second thought, I guess you don’t need it anymore.”</i>", parse);
+				Text.Add("<i>“Ah, all right. I had a recipe in mind that could increase the size of your knot a bit, but on second thought I guess you don’t need it anymore.”</i>", parse);
 			Text.Add(" The alchemist pats [hisher] lover on the head fondly before returning to [hisher] work, leaving you free to continue violating the wolf.", parse);
 		}, 1.0, function() { return true; });
 		scenes.AddEnc(function() {


### PR DESCRIPTION
Here are some additional things I've found. Few actual issues - others just suggestions for tweaks.

Line 290 - Perhaps add a sex level line that reflects the ability to take him all the way?
Line 298 - Perhaps a minor tweak for the deepthroat. If not high enough, you still try and manage with some difficulty. High = no problem and show off a little?
Line 468 - Add variation for slut Cale. I doubt he would try to get away from the pre-laced kiss.
Line 568 - Gender specific line?
Line 580 - Gender specific line?
Line 1048 - Cale's initial line needs another look | Offered a possible solution?
Line 1118 - "insides feel good" - probably should be for if real cock
Line 1451 - Needs tweak for legs/no legs in Cale-sex
Line 1480 - Needs tweak for legs/no legs in Cale-sex
Line 1863 - Perhaps an alternate line for the 'good for the skin' comment?