### PR TITLE
Added option to pack build output into tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ You are now ready to build the game by running the following commands at the roo
 	$ gulp build
 
 _Note: The build process only reduces file sizes, it is not required to run the game._
+
+If you want the output in archive form, you can instead run:
+
+	$ gulp pack
+
+This generates a set of files containing the build output in different archive formats. Feel free to choose the format that best suits your needs.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ const htmlreplace = require('gulp-html-replace');
 const uglify = require('gulp-uglify');
 const tar = require('gulp-tar');
 const zip = require('gulp-zip');
+const gzip = require('gulp-gzip');
 const del = require('del');
 const runSequence = require('run-sequence');
 const fs = require('fs');
@@ -238,7 +239,13 @@ const appJs = [
 // a release archive.
 function getArtifactFiles()
 {
-	var artifactFilter = filter(['*', '**/*', '!*.tar', '!*.zip']);
+	var artifactFilter = filter([
+		'*',
+		'**/*',
+		'!*.tar',
+		'!*tar.gz',
+		'!*.zip'
+	]);
 	return gulp.src(['./build/**/*'], {base: './build'})
 		.pipe(artifactFilter);
 }
@@ -248,7 +255,7 @@ gulp.task('build', (callback) => {
 		'build:app',
 		'build:css',
 		'build:html',
-		'build:misc',
+		'build:misc'
 	], callback);
 });
 
@@ -310,6 +317,7 @@ gulp.task('pack:zip', () => {
 gulp.task('pack:tar', () => {
 	return getArtifactFiles()
 		.pipe(tar(artifactName + '.tar'))
+		.pipe(gzip())
 		.pipe(gulp.dest('./build'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,8 +4,13 @@ const concat = require('gulp-concat');
 const filter = require('gulp-filter');
 const htmlreplace = require('gulp-html-replace');
 const uglify = require('gulp-uglify');
+const tar = require('gulp-tar')
 const del = require('del');
 const runSequence = require('run-sequence');
+const fs = require('fs')
+
+// Can't use 'require' here because of caching issues
+const package_info = JSON.parse(fs.readFileSync('./package.json'))
 
 // Include js files individually because the
 // load order is important.
@@ -232,7 +237,7 @@ gulp.task('build', (callback) => {
 		'build:app',
 		'build:css',
 		'build:html',
-		'build:misc'
+		'build:misc',
 	], callback);
 });
 
@@ -278,4 +283,13 @@ gulp.task('build:misc', () => {
 	.pipe(gulp.dest('./build'));
 });
 
-gulp.task('default', ['build']);
+gulp.task('pack', ['build'], () => {
+	var name = package_info.name + '-' + package_info.version + '.tar';
+	var artifactFilter = filter(['*', '**/*', '!*.tar']);
+	return gulp.src(['./build/**/*',], {base: './build'})
+		.pipe(artifactFilter)
+		.pipe(tar(name))
+		.pipe(gulp.dest('./build'))
+});
+
+gulp.task('default', ['build', 'pack']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-html-replace": "^1.5.5",
     "gulp-uglify": "^1.5.2",
     "gulp-tar": "^1.9.0",
+    "gulp-gzip": "^1.4.0",
     "gulp-zip": "^3.2.0",
     "run-sequence": "^1.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-filter": "^3.0.1",
     "gulp-html-replace": "^1.5.5",
     "gulp-uglify": "^1.5.2",
+    "gulp-tar": "^1.9.0",
     "run-sequence": "^1.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-html-replace": "^1.5.5",
     "gulp-uglify": "^1.5.2",
     "gulp-tar": "^1.9.0",
+    "gulp-zip": "^3.2.0",
     "run-sequence": "^1.1.5"
   }
 }


### PR DESCRIPTION
Like the title says, I added a 'pack' task to gulp that creates a tarball of the output.
Makes it easier to access and deploy the output using tools for automated release.