### PR TITLE
Automatically craft missing alchemic ingredients if possible

### DIFF
--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -132,17 +132,23 @@ Alchemy.ItemDetails = function(it, inventory) {
 	Text.Flush();
 }
 
-Alchemy.CountBrewable = function(it, inventory) {
+Alchemy.GetRecipeDict = function(it) {
 	var recipe = it.recipe;
 	var recipeDict = {};
-	var limitingQuota = Infinity;
-	var limiters = [];
-	var invDict = _.keyBy(inventory.ToStorage(), function(elem){return elem.it});
 
 	// There's always the possibility of some items being required more than once
 	recipe.forEach(function(ingredient) {
 		recipeDict[ingredient.it.id] = recipeDict[ingredient.it.id] + 1 || 1;
 	});
+
+	return recipeDict;
+}
+
+Alchemy.CountBrewable = function(it, inventory) {
+	var recipeDict = Alchemy.GetRecipeDict(it);
+	var limitingQuota = Infinity;
+	var limiters = [];
+	var invDict = _.keyBy(inventory.ToStorage(), function(elem){return elem.it});
 
 	Object.keys(recipeDict).forEach(function(ingredient) {
 		var available = invDict[ingredient].num;

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -91,11 +91,9 @@ Alchemy.MakeItem = function(it, qty, alchemist, inventory, backPrompt, callback)
 
 Alchemy.ItemDetails = function(it, inventory) {
 	var batchFormats = [1, 5, 10, 25];
-	var BrewBatch = function(batchSize) {
-		Alchemy.MakeItem(it, batchSize, player, inventory);
-	}
 	var list = [];
-	var brewable = Alchemy.CountBrewable(it.recipe, inventory);
+	var brewable = Alchemy.CountBrewable(it, inventory);
+	var BrewBatch = brewable.brewFn;
 	var inInventory = inventory.QueryNum(it);
 
 	var parser = {
@@ -134,7 +132,8 @@ Alchemy.ItemDetails = function(it, inventory) {
 	Text.Flush();
 }
 
-Alchemy.CountBrewable = function(recipe, inventory) {
+Alchemy.CountBrewable = function(it, inventory) {
+	var recipe = it.recipe;
 	var recipeDict = {};
 	var limitingQuota = Infinity;
 	var limiters = [];
@@ -156,5 +155,11 @@ Alchemy.CountBrewable = function(recipe, inventory) {
 		}
 	});
 
-	return {qty: limitingQuota, limiters: limiters};
+	return {
+		qty: limitingQuota,
+		limiters: limiters,
+		brewFn: function(batchSize){
+			Alchemy.MakeItem(it, batchSize, player, inventory);
+		}
+	};
 }

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -225,21 +225,18 @@ Alchemy.AdaptRecipe = function(recipeDict, invDict) {
 		} else if (_.includes(player.recipes, ingredientObj)) {
 			var ingredientRecipe = Alchemy.GetRecipeDict(ingredientObj);
 
-			// For the sake of simplicity, if there's not enough of an item to do the recipe once,
-			// the leftovers are considered to be equivalent amounts of their components.
+			// Set the amount for that ingredient to however many we have left
+			var missingAmount = recipeDict[ingredient] - invDict[ingredient];
+			recipeDict[ingredient] = invDict[ingredient]; // Most likely 0
+
 			Object.keys(ingredientRecipe).forEach(function(ingredientComponent) {
-				if (invDict[ingredient] !== 0) {
-					if (!invDict[ingredientComponent]) invDict[ingredientComponent] = 0;
-
-					invDict[ingredientComponent] += ingredientRecipe[ingredientComponent];
-				}
-
 				if(!recipeDict[ingredientComponent]) recipeDict[ingredientComponent] = 0;
-				// If item X is needed 3 times for a recipe, all of its ingredients are also needed 3 times.
-				recipeDict[ingredientComponent] += ingredientRecipe[ingredientComponent]*recipeDict[ingredient];
-			});
 
-			recipeDict[ingredient] = 0;
+				// If item X is needed 3 times for a recipe, all of its ingredients are also needed 3 times.
+				// If we need it 3 times but missingAmount is 1, only add the ingredients 1 time.
+				// The extra 2 times are for the next iteration
+				recipeDict[ingredientComponent] += ingredientRecipe[ingredientComponent]*missingAmount;
+			});
 		} else {
 			// Can't craft this, no need to look any further
 			return {};

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -28,7 +28,6 @@ Alchemy.AlchemyPrompt = function(alchemist, inventory, backPrompt, callback, pre
 		var knownRecipe = false;
 
 		var brewable = Alchemy.CountBrewable(item, inventory);
-		// FIXME: If the initial step is unavailable, weird stuff may happen.
 		var shallowQty = brewable.steps[0].qty;
 		var deepExtra = brewable.qty - shallowQty;
 		var enabled  = !(!brewable.qty);
@@ -190,7 +189,7 @@ Alchemy.CountBrewable = function(it, inventory) {
 		qty: _.map(productionSteps, 'qty').reduce(function(sum, qty) {
 			return sum += qty;
 		}, 0),
-		steps: productionSteps, // Should this be there?
+		steps: productionSteps,
 		brewFn: function(batchSize){
 			var amountProduced = 0;
 			productionSteps.some(function(step) {

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -137,6 +137,7 @@ Alchemy.CountBrewable = function(it, inventory) {
 	var recipeDict = {};
 	var limitingQuota = Infinity;
 	var limiters = [];
+	var invDict = _.keyBy(inventory.ToStorage(), function(elem){return elem.it});
 
 	// There's always the possibility of some items being required more than once
 	recipe.forEach(function(ingredient) {
@@ -144,16 +145,19 @@ Alchemy.CountBrewable = function(it, inventory) {
 	});
 
 	Object.keys(recipeDict).forEach(function(ingredient) {
-		var available = inventory.QueryNum(ItemIds[ingredient]);
+		var available = invDict[ingredient].num;
 		var quota = Math.floor(available/recipeDict[ingredient]);
 
-		if(quota < limitingQuota) {
-			limitingQuota = quota;
-			limiters = [ItemIds[ingredient]];
-		} else if (quota == limitingQuota) {
+		if(quota < limitingQuota) limitingQuota = quota;
+	});
+
+	Object.keys(recipeDict).forEach(function(ingredient) {
+		invDict[ingredient].num -= recipeDict[ingredient] * limitingQuota;
+
+		if(invDict[ingredient].num < recipeDict[ingredient]) {
 			limiters.push(ItemIds[ingredient]);
 		}
-	});
+    });
 
 	return {
 		qty: limitingQuota,

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -135,7 +135,8 @@ Alchemy.GetRecipeDict = function(it) {
 
 	// There's always the possibility of some items being required more than once
 	recipe.forEach(function(ingredient) {
-		recipeDict[ingredient.it.id] = recipeDict[ingredient.it.id] + 1 || 1;
+		if(!recipeDict[ingredient.it.id]) recipeDict[ingredient.it.id] = 0;
+		recipeDict[ingredient.it.id] =+ (ingredient.num || 1);
 	});
 
 	return recipeDict;

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -155,10 +155,10 @@ Alchemy.CountBrewable = function(it, inventory) {
 			if(quota < limitingQuota) limitingQuota = quota;
 		});
 
-		for (var ingredient of Object.keys(recipeDict)){
-			invDict[ingredient]-= recipeDict[ingredient] * limitingQuota;
-		}
-
+		Object.keys(recipeDict).forEach(function(ingredient) {
+			invDict[ingredient] -= recipeDict[ingredient] * limitingQuota;
+		});
+		
 		productionSteps.push({
 			recipe: recipeDict,
 			qty: limitingQuota,
@@ -174,7 +174,7 @@ Alchemy.CountBrewable = function(it, inventory) {
 		}, 0),
 		brewFn: function(batchSize){
 			var amountProduced = 0;
-			for(var step of productionSteps) {
+			productionSteps.some(function(step) {
 				var qty = Math.min(batchSize - amountProduced, step.qty);
 
 				Object.keys(step.recipe).forEach(function(componentId) {
@@ -182,8 +182,8 @@ Alchemy.CountBrewable = function(it, inventory) {
 				});
 
 				amountProduced += qty;
-				if (amountProduced >= batchSize) break;
-			}
+				return (amountProduced >= batchSize);
+			});
 
 			Alchemy.MakeItem(it, amountProduced, player, inventory, undefined, undefined, true);
 		},
@@ -194,7 +194,9 @@ Alchemy.AdaptRecipe = function(recipeDict, invDict) {
 	var origRecipeDict = recipeDict;
 	recipeDict = Object.assign({}, recipeDict);
 
-	for (var ingredient of Object.keys(recipeDict)){
+	var keys = Object.keys(recipeDict);
+	for(var i = 0; i < keys.length; i++) {
+		var ingredient = keys[i];
 		if(recipeDict[ingredient] == 0) continue;
 
 		var ingredientObj = ItemIds[ingredient];

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -216,8 +216,9 @@ Alchemy.AdaptRecipe = function(recipeDict, invDict) {
 					invDict[ingredientComponent] += ingredientRecipe[ingredientComponent];
 				}
 
-				recipeDict[ingredientComponent] =
-					(recipeDict[ingredientComponent] || 0) + ingredientRecipe[ingredientComponent];
+				if(!recipeDict[ingredientComponent]) recipeDict[ingredientComponent] = 0;
+				// If item X is needed 3 times for a recipe, all of its ingredients are also needed 3 times.
+				recipeDict[ingredientComponent] += ingredientRecipe[ingredientComponent]*recipeDict[ingredient];
 			});
 
 			recipeDict[ingredient] = 0;

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -25,9 +25,16 @@ Alchemy.AlchemyPrompt = function(alchemist, inventory, backPrompt, callback, pre
 	}
 
 	alchemist.recipes.forEach(function(item) {
-		var enabled = true;
 		var knownRecipe = false;
-		var str = Text.BoldColor(item.name) + ": ";
+
+		var brewable = Alchemy.CountBrewable(item, inventory);
+		// FIXME: If the initial step is unavailable, weird stuff may happen.
+		var shallowQty = brewable.steps[0].qty;
+		var deepExtra = brewable.qty - shallowQty;
+		var enabled  = !(!brewable.qty);
+
+		var str = Text.BoldColor(item.name);
+		str += " ("+ shallowQty + ((deepExtra) ? " + " + deepExtra : "") +")"  + ": ";
 		item.recipe.forEach(function(component, idx) {
 			var available = inventory.QueryNum(component.it) || 0;
 			var enough = (available >= (component.num || 1));
@@ -35,7 +42,6 @@ Alchemy.AlchemyPrompt = function(alchemist, inventory, backPrompt, callback, pre
 			if(!enough) str += "<b>";
 			str += (component.num || 1) + "/" + available + "x " + component.it.name;
 			if(!enough) str += "</b>";
-			enabled &= enough;
 		});
 
 		if(alchemist == player) {


### PR DESCRIPTION
Fixes #443 

I've tried a number of approaches for this, and while this isn't quite as clean as I'd initially hoped, it actually works rather well.

A good way to see the proposed effects is to grab a certain amount of items in debug mode and attempt brewing Testos. Using the debug mode item granting option `n` times formally gives you `n` amount of all the items in the game, meaning you should normally only be able to brew Testos `n` times. However, all the ingredients required by Testos are also craftable with non-overlapping ingredients, meaning you should actually have enough material to craft `2*n` instead.

Note you will also be limited to `n` if you do not know the recipes for Equinium, Homos and Canis as well, which is intended.

The change is transparent for the user and testing did not reveal any interaction with alchemist NPCs. The only issue so far is that the alchemy menu itself still only lists the "shallow" crafting results, and will not let you craft Testos (for example) if you do not have at least one of all the "real" ingredients, regardless of the raw ingredients you could use instead.