### PR TITLE
Refactored Text.BoldColor()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/*
 .project
 desktop.ini
 node_modules
+.vscode/*
+yarn.lock

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,3 +91,58 @@ table.party td {
 	border-color: black;
 	-moz-border-radius: ;
 }
+
+/* Used in Text.Parse for any parser errors */
+span.error {
+	color: red;
+	text-decoration: underline;
+	font-weight: bold;
+}
+
+/* Used to replace Text.BoldColor */
+.bold {
+	font-weight: bold;
+}
+
+/* Prep, so this can be handled by css class instead of <i> tags */
+.spoken {
+	font-style: italic;
+}
+
+/* These are the 'stat' colors for the UI */
+.life {
+	color: red;
+}
+.mana {
+	color: blue;
+}
+.lust {
+	color: pink;
+}
+.heal {
+	color: #008000;
+}
+/*
+I think this is a better choice for soothe,
+since it's far enough from SP/mana to be obvious
+.soothe {
+	color: #005f5f; 
+}
+*/
+.soothe {
+	color: #000060;
+}
+
+/* These should be safe to replace with the above now */
+.pink {
+	color: #ff8080;
+}
+.green {
+	color: #008000;
+}
+.red {
+	color: #800000;
+}
+.blue {
+	color: #000080;
+}

--- a/js/ability.js
+++ b/js/ability.js
@@ -304,12 +304,12 @@ Ability.prototype.enabledTargetCondition = function(encounter, caster, target) {
 Ability.prototype.CostStr = function() {
 	var str = "";
 	if(this.cost.hp || this.cost.sp || this.cost.lp) {
-		if(this.cost.hp) str += Text.BoldColor(this.cost.hp + "HP ", "red");
-		if(this.cost.sp) str += Text.BoldColor(this.cost.sp + "SP ", "blue");
-		if(this.cost.lp) str += Text.BoldColor(this.cost.lp + "LP ", "pink");
+		if(this.cost.hp) str += Text.Damage(this.cost.hp + "HP ");
+		if(this.cost.sp) str += Text.Mana(this.cost.sp + "SP ");
+		if(this.cost.lp) str += Text.Lust(this.cost.lp + "LP ");
 	}
 	else
-		return "free";
+		return Text.Bold("Free");
 
 	return str;
 }

--- a/js/ability/attack.js
+++ b/js/ability/attack.js
@@ -12,10 +12,10 @@ Abilities.Attack.castTree.push(AbilityNode.Template.Physical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[Name] attack[notS] [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage! Waagh!", parse);
+		Text.Add("[Name] attack[notS] [tname] for " + Text.Damage(-dmg) + " damage! Waagh!", parse);
 	}],
 	onAbsorb: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[Name] attack[notS] [tname], but [theshe] absorb[tnotS] the blow for " + Text.BoldColor(dmg, "#008000") + " damage!");
+		Text.Add("[Name] attack[notS] [tname], but [theshe] absorb[tnotS] the blow for " + Text.Heal(dmg) + " damage!");
 	}]
 }));

--- a/js/ability/black.js
+++ b/js/ability/black.js
@@ -8,12 +8,12 @@ Abilities.Black = {};
 // Default messages
 Abilities.Black._onDamage = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("It hits [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+	Text.Add("It hits [tname] for " + Text.Damage(-dmg) + " damage!", parse);
 	Text.NL();
 }
 Abilities.Black._onAbsorb = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] absorb[tnotS] the spell, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+	Text.Add("[tName] absorb[tnotS] the spell, gaining " + Text.Heal(dmg) + " health!", parse);
 	Text.NL();
 }
 Abilities.Black._onMiss = function(ability, encounter, caster, target) {
@@ -53,7 +53,7 @@ Abilities.Black.Fireball.castTree.push(AbilityNode.Template.Magical({
 	onDamage: [Abilities.Black._onDamage],
 	onAbsorb: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] absorb[tnotS] the flames, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+		Text.Add("[tName] absorb[tnotS] the flames, gaining " + Text.Heal(dmg) + " health!", parse);
 	}],
 	onHit: [function(ability, encounter, caster, target) {
 		var parse = AbilityNode.DefaultParser(caster, target);
@@ -104,7 +104,7 @@ Abilities.Black.Bolt.castTree.push(AbilityNode.Template.Magical({
 	onDamage: [Abilities.Black._onDamage],
 	onAbsorb: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.Heal(dmg) + " health!", parse);
 	}],
 	onHit: [function(ability, encounter, caster, target) {
 		var parse = AbilityNode.DefaultParser(caster, target);
@@ -347,7 +347,7 @@ Abilities.Black.Shock.castTree.push(AbilityNode.Template.Magical({
 	onDamage: [Abilities.Black._onDamage],
 	onAbsorb: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.Heal(dmg) + " health!", parse);
 	}],
 	onHit: [function(ability, encounter, caster, target) {
 		var parse = AbilityNode.DefaultParser(caster, target);
@@ -377,7 +377,7 @@ Abilities.Black.ThunderStorm.castTree.push(AbilityNode.Template.Magical({
 	onDamage: [Abilities.Black._onDamage],
 	onAbsorb: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+		Text.Add("[tName] absorb[tnotS] the shock, gaining " + Text.Heal(dmg) + " health!", parse);
 		Text.NL();
 	}],
 	onHit: [function(ability, encounter, caster, target) {
@@ -467,7 +467,7 @@ Abilities.Black.Scream.castTree.push(AbilityNode.Template.Magical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] [tis] severely buffeted by the sudden burst of sound, taking " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("[tName] [tis] severely buffeted by the sudden burst of sound, taking " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.Black._onAbsorb],
@@ -520,7 +520,7 @@ Abilities.Black.DrainingTouch.castTree.push(AbilityNode.Template.Magical({
 	onMiss: [Abilities.Black._onMiss],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("The tendrils wrap themselves about [tname], leeching " + Text.BoldColor(-dmg, "#800000") + " health from [thimher]!", parse);
+		Text.Add("The tendrils wrap themselves about [tname], leeching " + Text.Damage(-dmg) + " health from [thimher]!", parse);
 		Text.NL();
 		caster.AddHPAbs(-dmg);
 	}],
@@ -605,7 +605,7 @@ Abilities.Black.Lifetap.castTree.push(function(ability, encounter, caster, targe
 	caster.AddHPAbs(-hp);
 	caster.AddSPAbs(hp);
 	
-	Text.Add("[Name] focus[notEs] inwards, drawing upon [hisher] own life force to power [hisher] abilities! [Name] gain[notS] " + Text.BoldColor(hp, "#000080") + " SP!", parse);
+	Text.Add("[Name] focus[notEs] inwards, drawing upon [hisher] own life force to power [hisher] abilities! [Name] gain[notS] " + Text.Mana(hp) + " SP!", parse);
 	Text.NL();
 });
 

--- a/js/ability/enemyskill.js
+++ b/js/ability/enemyskill.js
@@ -17,7 +17,7 @@ Abilities.EnemySkill.Sting.castTree.push(AbilityNode.Template.Physical({
 	onMiss: [Abilities.Physical._onMiss],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[Name] sting[notS] [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("[Name] sting[notS] [tname] for " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.Physical._onAbsorb],
@@ -135,7 +135,7 @@ Abilities.EnemySkill.TRavage.castTree.push(AbilityNode.Template.Physical({
 		Text.NL();
 		Text.Add("[tName] only barely manage[tnotS] to break [poss] hold on [thimher], but not before the tentacles have gotten real close and personal.", parse);
 		Text.NL();
-		Text.Add("[tName] take[tnotS] " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("[tName] take[tnotS] " + Text.Damage(-dmg) + " damage!", parse);
 		target.AddLustFraction(0.3);
 	}],
 	onAbsorb: [Abilities.Physical._onAbsorb]
@@ -157,7 +157,7 @@ Abilities.EnemySkill.TWhip.castTree.push(AbilityNode.Template.Physical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] [tis] unable to avoid the blow, and stagger[tnotS] back as it hits, dealing " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("[tName] [tis] unable to avoid the blow, and stagger[tnotS] back as it hits, dealing " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 		target.AddLustFraction(0.3);
 	}],
@@ -225,7 +225,7 @@ Abilities.EnemySkill.TViolate.castTree.push(AbilityNode.Template.Physical({
 		var dmg = Math.floor(target.curLust);
 		target.AddHPAbs(-dmg);
 		
-		Text.Add("[tName] take[tnotS] " + Text.BoldColor(dmg, "#800000") + " damage!", parse);
+		Text.Add("[tName] take[tnotS] " + Text.Damage(dmg) + " damage!", parse);
 		
 		var cum = target.OrgasmCum();
 	}]
@@ -280,7 +280,7 @@ Abilities.EnemySkill.GolCuntDash.castTree.push(AbilityNode.Template.Physical({
 		parse["feet"] = target.FeetDesc();
 		Text.Add("[tName] react[tnotS] a little too late to dive out the way, but [theshe] manage[tnotS] to duck low in an attempt to slip under her scythes… just not low enough. Her oncoming crotch and abdomen smack into [tname], and her fragrant pussy drags across [tposs] face and slimes it with a thick coat of her vaginal juices. The chitin of her underbelly is quite soft on [tposs] cheek, almost like a pleasant caress.", parse);
 		Text.NL();
-		Text.Add("The Gol queen bashes [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage, staggering [thimher]!", parse);
+		Text.Add("The Gol queen bashes [tname] for " + Text.Damage(-dmg) + " damage, staggering [thimher]!", parse);
 		Text.NL();
 		Text.Add("When she finishes charging past, [tname] blink[tnotS] in a daze and stagger back on [thisher] [feet], uncomfortably warm in all the wrong places.", parse);
 		target.AddLustFraction(0.3);
@@ -371,7 +371,7 @@ Abilities.EnemySkill.Corishev.Lashing.castTree.push(AbilityNode.Template.Physica
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
 		parse["skin"] = target.SkinDesc();
-		Text.Add("The barbed tip of the poisoned whip slashes across [tposs] [skin], dealing " + Text.BoldColor(-dmg, "#800000") + " damage! ", parse);
+		Text.Add("The barbed tip of the poisoned whip slashes across [tposs] [skin], dealing " + Text.Damage(-dmg) + " damage! ", parse);
 	}],
 	onAbsorb: [Abilities.Physical._onAbsorb]
 }));
@@ -396,7 +396,7 @@ Abilities.EnemySkill.Corishev.WideStrike.castTree.push(AbilityNode.Template.Phys
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("Poisoned barbs sink into [tposs] flesh, causing [thimher] to take " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("Poisoned barbs sink into [tposs] flesh, causing [thimher] to take " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.Physical._onAbsorb]
@@ -437,7 +437,7 @@ Abilities.EnemySkill.Corishev.Punish.castTree.push(AbilityNode.Template.Physical
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("Caught by surprise - or perhaps distracted by [thisher] pounding heart - [tname] [tis] unable to dodge the flurry of blows raining down on [thimher]. [tHeShe] cr[ty] out in pain as the whip lacerates [thisher] flesh time and time again, dealing " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("Caught by surprise - or perhaps distracted by [thisher] pounding heart - [tname] [tis] unable to dodge the flurry of blows raining down on [thimher]. [tHeShe] cr[ty] out in pain as the whip lacerates [thisher] flesh time and time again, dealing " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.Physical._onAbsorb],
@@ -475,7 +475,7 @@ Abilities.EnemySkill.Cassidy.TailSlap.castTree.push(AbilityNode.Template.Physica
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("The weight of Cassidy’s flaming tail smacks you silly! You take " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("The weight of Cassidy’s flaming tail smacks you silly! You take " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}, AbilityNode.Template.Cancel()],
 	onAbsorb: [Abilities.Physical._onAbsorb],
@@ -508,7 +508,7 @@ Abilities.EnemySkill.Cassidy.Smoke.castTree.push(AbilityNode.Template.Physical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("The cinders burn you! You take " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("The cinders burn you! You take " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}, AbilityNode.Template.Cancel()],
 	onAbsorb: [Abilities.Physical._onAbsorb],
@@ -564,7 +564,7 @@ Abilities.EnemySkill.Cassidy.Impact.castTree.push(AbilityNode.Template.Physical(
 		var parse = AbilityNode.DefaultParser(caster, target);
 		Text.Add("<i>“Heh. Here goes nothing!”</i> Cass roars as she brings her war hammer down, its head wreathed in flame. <i>“I pity you, ace - you’re gonna have a bad time!”</i>", parse);
 		Text.NL();
-		Text.Add("Gah! You reel as Cass’ hammer connects with the impact of a fiery meteor, shaking you to the bone and burning you badly! You take " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+		Text.Add("Gah! You reel as Cass’ hammer connects with the impact of a fiery meteor, shaking you to the bone and burning you badly! You take " + Text.Damage(-dmg) + " damage!", parse);
 		Text.NL();
 	}, AbilityNode.Template.Cancel()],
 	onAbsorb: [Abilities.Physical._onAbsorb],

--- a/js/ability/physical.js
+++ b/js/ability/physical.js
@@ -8,7 +8,7 @@ Abilities.Physical = {};
 // Default messages
 Abilities.Physical._onDamage = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("The attack hits [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage!", parse);
+	Text.Add("The attack hits [tname] for " + Text.Damage(-dmg) + " damage!", parse);
 	Text.NL();
 }
 Abilities.Physical._onMiss = function(ability, encounter, caster, target) {
@@ -18,7 +18,7 @@ Abilities.Physical._onMiss = function(ability, encounter, caster, target) {
 }
 Abilities.Physical._onAbsorb = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] absorb[tnotS] the attack, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+	Text.Add("[tName] absorb[tnotS] the attack, gaining " + Text.Heal(dmg) + " health!", parse);
 	Text.NL();
 }
 
@@ -46,7 +46,7 @@ Abilities.Physical.Bash.castTree.push(AbilityNode.Template.Physical({
 		
 		var parse = AbilityNode.DefaultParser(caster, target);
 		
-		Text.Add("[Name] bash[notEs] [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage, staggering [thimher]!", parse);
+		Text.Add("[Name] bash[notEs] [tname] for " + Text.Damage(-dmg) + " damage, staggering [thimher]!", parse);
 		Text.NL();
 	}, AbilityNode.Template.Cancel()],
 	onAbsorb: [Abilities.Physical._onAbsorb]
@@ -77,7 +77,7 @@ Abilities.Physical.GrandSlam.castTree.push(AbilityNode.Template.Physical({
 		
 		var parse = AbilityNode.DefaultParser(caster, target);
 		
-		Text.Add("[Name] slam[notS] [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage, staggering [thimher]!", parse);
+		Text.Add("[Name] slam[notS] [tname] for " + Text.Damage(-dmg) + " damage, staggering [thimher]!", parse);
 		Text.NL();
 	}, AbilityNode.Template.Cancel()],
 	onAbsorb: [Abilities.Physical._onAbsorb]
@@ -382,7 +382,7 @@ Abilities.Physical.CrushingStrike.castTree.push(AbilityNode.Template.Physical({
 	onMiss: [Abilities.Physical._onMiss],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[Name] deliver[notS] a crushing blow to [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage, staggering [thimher]!", parse);
+		Text.Add("[Name] deliver[notS] a crushing blow to [tname] for " + Text.Damage(-dmg) + " damage, staggering [thimher]!", parse);
 	}],
 	onHit: [function(ability, encounter, caster, target) {
 		if(Math.random() < 0.8) {

--- a/js/ability/seduction.js
+++ b/js/ability/seduction.js
@@ -8,12 +8,12 @@ Abilities.Seduction = {};
 // Default messages
 Abilities.Seduction._onDamage = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] become[tnotS] aroused, gaining " + Text.BoldColor(-dmg, "#FF8080") + " lust!", parse);
+	Text.Add("[tName] become[tnotS] aroused, gaining " + Text.Lust(-dmg) + " lust!", parse);
 	Text.NL();
 }
 Abilities.Seduction._onAbsorb = function(ability, encounter, caster, target, dmg) {
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] [tis] turned off, losing " + Text.BoldColor(dmg, "#000060") + " lust!", parse);
+	Text.Add("[tName] [tis] turned off, losing " + Text.Soothe(dmg) + " lust!", parse);
 	Text.NL();
 }
 Abilities.Seduction._onMiss = function(ability, encounter, caster, target) {
@@ -146,7 +146,7 @@ Abilities.Seduction.Rut.castTree.push(AbilityNode.Template.Lust({
 		target.AddLustAbs(-dmg*0.25);
 	}, function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[Name] rut[notS] against [tname] for " + Text.BoldColor(-dmg, "#800000") + " damage! Sexy!", parse);
+		Text.Add("[Name] rut[notS] against [tname] for " + Text.Damage(-dmg) + " damage! Sexy!", parse);
 	}]
 }));
 
@@ -166,7 +166,7 @@ Abilities.Seduction.Fantasize.castTree.push(function(ability, encounter, caster)
 	}
 
 	// TODO: Make more flavor text	
-	Text.Add("[name] fantasizes, building " + Text.BoldColor(dmg, "#FF8080") + " lust! Sexy!", parse);
+	Text.Add("[name] fantasizes, building " + Text.Lust(dmg) + " lust! Sexy!", parse);
 });
 
 
@@ -195,7 +195,7 @@ Abilities.Seduction.Soothe.castTree.push(function(ability, encounter, caster, ta
 		
 		var parse = AbilityNode.DefaultParser(null, e);
 		Text.NL();
-		Text.Add("The music washes over [tposs] mind, leaving [thimher] feeling clean and pristine. [tName] lose[tnotS] " + Text.BoldColor(soothe, "#000060") + " lust!", parse);
+		Text.Add("The music washes over [tposs] mind, leaving [thimher] feeling clean and pristine. [tName] lose[tnotS] " + Text.Soothe(soothe) + " lust!", parse);
 	});
 });
 

--- a/js/ability/tease.js
+++ b/js/ability/tease.js
@@ -73,7 +73,7 @@ Abilities.Seduction.Distract.castTree.push(AbilityNode.Template.Lust({
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		target.GetCombatEntry(encounter).initiative -= 25;
 		var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] become[tnotS] aroused, gaining " + Text.BoldColor(-dmg, "#FF8080") + " lust! [tHeShe] become[tnotS] distracted.", parse);
+	Text.Add("[tName] become[tnotS] aroused, gaining " + Text.Lust(-dmg) + " lust! [tHeShe] become[tnotS] distracted.", parse);
 	}],
 	onAbsorb: [Abilities.Seduction._onAbsorb]
 }));
@@ -99,7 +99,7 @@ Abilities.Seduction.Charm.castTree.push(AbilityNode.Template.Lust({
 			if(aggroEntry.aggro < 0) aggroEntry.aggro = 0;
 		}	
 		var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] become[tnotS] charmed, gaining " + Text.BoldColor(-dmg, "#FF8080") + " lust! [tHeShe] become[tnotS] less aggressive toward [name].", parse);
+	Text.Add("[tName] become[tnotS] charmed, gaining " + Text.Lust(-dmg) + " lust! [tHeShe] become[tnotS] less aggressive toward [name].", parse);
 	}],
 	onAbsorb: [Abilities.Seduction._onAbsorb]
 }));
@@ -124,7 +124,7 @@ Abilities.Seduction.Allure.castTree.push(AbilityNode.Template.Lust({
 			if(aggroEntry.aggro < 0) aggroEntry.aggro = 0;
 		}	
 		var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("[tName] become[tnotS] charmed, gaining " + Text.BoldColor(-dmg, "#FF8080") + " lust! [tHeShe] become[tnotS] less aggressive toward [name].", parse);
+	Text.Add("[tName] become[tnotS] charmed, gaining " + Text.Lust(-dmg) + " lust! [tHeShe] become[tnotS] less aggressive toward [name].", parse);
 	}],
 	onAbsorb: [Abilities.Seduction._onAbsorb]
 }));
@@ -143,7 +143,7 @@ Abilities.Seduction.Inflame.castTree.push(AbilityNode.Template.Lust({
 	onMiss: [Abilities.Seduction._onMiss],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("[tName] squirm[tnotS] at the subtle undertones of the song, becoming greatly aroused. [tName] gain[tnotS] " + Text.BoldColor(-dmg, "#FF8080") + " lust!", parse);
+		Text.Add("[tName] squirm[tnotS] at the subtle undertones of the song, becoming greatly aroused. [tName] gain[tnotS] " + Text.Lust(-dmg) + " lust!", parse);
 	}],
 	onAbsorb: [function(ability, encounter, caster, target) {
 		var parse = AbilityNode.DefaultParser(caster, target);

--- a/js/ability/white.js
+++ b/js/ability/white.js
@@ -9,7 +9,7 @@ Abilities.White = {};
 Abilities.White._onHeal = function(ability, encounter, caster, target, dmg) {
 	if(dmg <= 0) return;
 	var parse = AbilityNode.DefaultParser(caster, target);
-	Text.Add("It heals [tname] for " + Text.BoldColor(dmg, "#008000") + " damage!", parse);
+	Text.Add("It heals [tname] for " + Text.Heal(dmg) + " damage!", parse);
 	Text.NL();
 }
 
@@ -184,7 +184,7 @@ Abilities.White.Tirade.castTree.push(AbilityNode.Template.Magical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add(" in an attempt to distract [tname]. It seems to be working, [theshe] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.BoldColor(-dmg, "#000080") + " SP from [tname]!", parse);
+		Text.Add(" in an attempt to distract [tname]. It seems to be working, [theshe] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.Mana(-dmg) + " SP from [tname]!", parse);
 	}],
 	onAbsorb: [Abilities.White.Tirade._onMiss],
 	onMiss: [Abilities.White.Tirade._onMiss]
@@ -212,7 +212,7 @@ Abilities.White.Preach.castTree.push(AbilityNode.Template.Magical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("It seems to be working, [tname] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.BoldColor(-dmg, "#000080") + " SP from [tname]!", parse);
+		Text.Add("It seems to be working, [tname] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.Mana(-dmg) + " SP from [tname]!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.White.Preach._onMiss],
@@ -237,7 +237,7 @@ Abilities.White.Sermon.castTree.push(AbilityNode.Template.Magical({
 	}],
 	onDamage: [function(ability, encounter, caster, target, dmg) {
 		var parse = AbilityNode.DefaultParser(caster, target);
-		Text.Add("It seems to be working, [tname] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.BoldColor(-dmg, "#000080") + " SP from [tname]!", parse);
+		Text.Add("It seems to be working, [tname] look[tnotS] slightly annoyed! [Name] drain[notS] " + Text.Mana(-dmg) + " SP from [tname]!", parse);
 		Text.NL();
 	}],
 	onAbsorb: [Abilities.White.Preach._onMiss],

--- a/js/alchemy.js
+++ b/js/alchemy.js
@@ -32,7 +32,7 @@ Alchemy.AlchemyPrompt = function(alchemist, inventory, backPrompt, callback, pre
 		var deepExtra = brewable.qty - shallowQty;
 		var enabled  = !(!brewable.qty);
 
-		var str = Text.BoldColor(item.name);
+		var str = Text.Bold(item.name);
 		str += " ("+ shallowQty + ((deepExtra) ? " + " + deepExtra : "") +")"  + ": ";
 		item.recipe.forEach(function(component, idx) {
 			var available = inventory.QueryNum(component.it) || 0;

--- a/js/cheats.js
+++ b/js/cheats.js
@@ -3,7 +3,7 @@
 world.loc.Plains.Nomads.Tent.events.push(new Link(
 	"TESTBUTTON", function() { return DEBUG; }, true,
 	function() {
-		Text.Add(Text.BoldColor("DEBUG: " + "Time"));
+		Text.Add(Text.Bold("DEBUG: " + "Time"));
 		Text.NL();
 		Text.Flush();
 	},
@@ -19,7 +19,7 @@ world.loc.Plains.Nomads.Tent.events.push(new Link(
 	function() {
 		if(DEBUG) {
 			Text.NL();
-			Text.Add(Text.BoldColor("Mr. Johnson, the cocksmith, is sitting inconspicuously in a corner."));
+			Text.Add(Text.Bold("Mr. Johnson, the cocksmith, is sitting inconspicuously in a corner."));
 			Text.NL();
 		}
 	},
@@ -27,7 +27,7 @@ world.loc.Plains.Nomads.Tent.events.push(new Link(
 		Text.Clear();
 		Text.Add("Jolly good to see you chap, what can I do for you?");
 		Text.NL();
-		Text.Add(Text.BoldColor("DEBUG: This is a cheat-shop, where you can change your characters body."));
+		Text.Add(Text.Bold("DEBUG: This is a cheat-shop, where you can change your characters body."));
 		Text.NL();
 		
 		var CockSmith = function() {
@@ -211,7 +211,7 @@ world.loc.Plains.Nomads.Tent.events.push(new Link(
 	function() {
 		if(DEBUG) {
 			Text.NL();
-			Text.Add(Text.BoldColor("Inra, the elf calibrator, is sitting in a corner."));
+			Text.Add(Text.Bold("Inra, the elf calibrator, is sitting in a corner."));
 			Text.NL();
 		}
 	},
@@ -225,7 +225,7 @@ world.loc.Plains.Nomads.Tent.events.push(new Link(
 		Text.Clear();
 		Text.Add("<i>“Need your elf recalibrated?”</i>");
 		Text.NL();
-		Text.Add(Text.BoldColor("DEBUG: This is a cheat-shop, where you can modify [name]."), parse);
+		Text.Add("DEBUG: This is a cheat-shop, where you can modify [name].", parse, "bold");
 		Text.NL();
 		
 		var ElfSmith = function() {
@@ -463,7 +463,7 @@ world.loc.Plains.Nomads.Tent.events.push(new Link(
 	function() {
 		if(DEBUG) {
 			Text.NL();
-			Text.Add(Text.BoldColor("A box of cheaty items."));
+			Text.Add(Text.Bold("A box of cheaty items."));
 			Text.NL();
 		}
 	},

--- a/js/entity-menu.js
+++ b/js/entity-menu.js
@@ -31,7 +31,7 @@ Entity.prototype.LevelUpPrompt = function(backFunc) {
 	Text.Clear();
 
 	Text.Add("[name] has [points] stat points pending.",
-		{name: this.name, points: this.pendingStatPoints != 0 ? Text.BoldColor(this.pendingStatPoints) : "no"});
+		{name: this.name, points: this.pendingStatPoints != 0 ? Text.Bold(this.pendingStatPoints) : "no"});
 
 	Text.NL();
 

--- a/js/items/combatitems.js
+++ b/js/items/combatitems.js
@@ -27,7 +27,7 @@ CombatItem.prototype.constructor = CombatItem;
 // Default messages
 CombatItem._onDamage = function(ability, encounter, caster, target, dmg) {
 	var parse = { tName : target.nameDesc() };
-	Text.Add("The attack hits [tName] for " + Text.BoldColor(dmg, "#800000") + " damage!", parse);
+	Text.Add("The attack hits [tName] for " + Text.Damage(dmg) + " damage!", parse);
 	Text.NL();
 }
 CombatItem._onMiss = function(ability, encounter, caster, target) {
@@ -37,7 +37,7 @@ CombatItem._onMiss = function(ability, encounter, caster, target) {
 }
 CombatItem._onAbsorb = function(ability, encounter, caster, target, dmg) {
 	var parse = { tName : target.NameDesc(), s : target.plural() ? "" : "s" };
-	Text.Add("[tName] absorb[s] the attack, gaining " + Text.BoldColor(dmg, "#008000") + " health!", parse);
+	Text.Add("[tName] absorb[s] the attack, gaining " + Text.Heal(dmg) + " health!", parse);
 	Text.NL();
 }
 
@@ -55,7 +55,7 @@ Items.Combat.HPotion.combat.castTree.push(function(ability, encounter, caster, t
 	var parse = AbilityNode.DefaultParser(caster, target);
 	Text.Add("[Name] use[notS] a potion.", parse);
 	Text.NL();
-	Text.Add("It heals [tname] for " + Text.BoldColor(100, "#008000") + "!", parse);
+	Text.Add("It heals [tname] for " + Text.Heal(100) + "!", parse);
 	
 	target.AddHPAbs(100);
 });
@@ -71,7 +71,7 @@ Items.Combat.EPotion.combat.castTree.push(function(ability, encounter, caster, t
 	var parse = AbilityNode.DefaultParser(caster, target);
 	Text.Add("[Name] use[notS] an energy potion.", parse);
 	Text.NL();
-	Text.Add("A brief surge of energy runs through [tname], restoring " + Text.BoldColor(100, "#000080") + " points of energy!", parse);
+	Text.Add("A brief surge of energy runs through [tname], restoring " + Text.Mana(100) + " points of energy!", parse);
 	
 	target.AddSPAbs(100);
 });

--- a/js/party.js
+++ b/js/party.js
@@ -432,7 +432,7 @@ Party.prototype.ShowAbilities = function() {
 					var en = ability.enabledCondition(null, entity);
 
 					Text.Add("[name] can use [ability] for [cost]: [desc]<br>",
-						{name: Text.BoldColor(entity.name), ability: ability.name, cost: ability.CostStr(), desc: ability.Short()});
+						{name: Text.Bold(entity.name), ability: ability.name, cost: ability.CostStr(), desc: ability.Short()});
 
 					list.push({
 						nameStr : ability.name,

--- a/js/quest.js
+++ b/js/quest.js
@@ -90,7 +90,7 @@ Quests.Print = function() {
 	if(numQs > 0)
 		Text.Add("<hr>");
 	else {
-		Text.Add(Text.BoldColor("No active quests."));
+		Text.Add("No active quests.", null, "bold");
 	}
 	Text.Flush();
 	

--- a/js/stat.js
+++ b/js/stat.js
@@ -31,11 +31,11 @@ Stat.prototype.IdealStat = function(ideal, maxChange, fraction) {
 	if(DEBUG && this.debug) {
 		Text.NL();
 		if(diff > 0)
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (ideal: " + ideal + ")", "blue"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (ideal: " + ideal + ")", null, "blue bold");
 		else if(diff == 0)
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", "black"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", null, "bold");
 		else
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (ideal: " + ideal + ")", "red"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (ideal: " + ideal + ")", null, "red bold");
 		Text.NL();
 		Text.Flush();
 	}
@@ -59,9 +59,9 @@ Stat.prototype.IncreaseStat = function(ideal, maxChange, fraction) {
 	if(DEBUG && this.debug) {
 		Text.NL();
 		if(diff == 0)
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", "black"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", null, "black bold");
 		else
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (max: " + ideal + ")", "blue"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (max: " + ideal + ")", null, "blue bold");
 		Text.NL();
 		Text.Flush();
 	}
@@ -85,9 +85,9 @@ Stat.prototype.DecreaseStat = function(ideal, maxChange, fraction) {
 	if(DEBUG && this.debug) {
 		Text.NL();
 		if(diff == 0)
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", "black"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " capped (ideal: " + ideal + ")", null, "black bold");
 		else
-			Text.Add(Text.BoldColor("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (min: " + ideal + ")", "red"));
+			Text.Add("DEBUG: " + this.debug() + " " + old + " -> " + this.base + " (min: " + ideal + ")", null, "red bold");
 		Text.NL();
 		Text.Flush();
 	}


### PR DESCRIPTION
- Add CSS styles for existing uses of BoldColor()
- Add Text.ApplyStyle() function, used to add css classes to text anywhere needed
- Add several Text. helper functions for consistent coloring of combat notices
- Add Text.AddSpan() function, which is equivalent to always use span tags
- Refactor Text.AddDiv() function to use Text.ApplyStyle()
- Refactor Text.Add() function to accept classes and tag overrides
- Refactor Text.Parse() to use Text.ApplyStyle
- Refactor all uses of Text.BoldColor() to use either ApplyStyle or Add